### PR TITLE
Added tuples for global constant categories and input validation on service_types property of DiscoveryResponse.ServiceInstance class

### DIFF
--- a/libtaxii/messages.py
+++ b/libtaxii/messages.py
@@ -79,7 +79,7 @@ ACT_SUBSCRIBE = 'SUBSCRIBE'
 ACT_UNSUBSCRIBE = 'UNSUBSCRIBE'
 #: Constant identifying an Action of Status
 ACT_STATUS = 'STATUS'
-# Tuple of all Actions
+# Tuple of all actions
 ACT_TYPES = (ACT_SUBSCRIBE, ACT_UNSUBSCRIBE, ACT_STATUS)
 
 #Service types


### PR DESCRIPTION
I added tuples for status types, service types, actions, and message types that include all respective global constants. This should make input validation somewhat easier for libtaxii or code which leverages libtaxii.

I also added input validation to the DiscoveryResponse.ServiceInstance.service_type setter, requiring it to be one of the SVC_TYPE members (e.g., INBOX, POLL, DISCOVERY, or FEED_MANAGEMENT). 

This may or may not align with the vision for libtaxii.
