### PR TITLE
Attempt to convert content to Unicode.

### DIFF
--- a/libtaxii/messages.py
+++ b/libtaxii/messages.py
@@ -754,6 +754,10 @@ class ContentBlock(BaseNonMessage):
     @content.setter
     def content(self, value):
         _do_check(value, 'content')#Just check for not None
+        if isinstance(value, str):
+            value = value.decode('utf-8')
+        elif not isinstance(value, unicode):
+            value = unicode(value)
         self._content = value
     
     @property
@@ -787,7 +791,6 @@ class ContentBlock(BaseNonMessage):
                 c.append(xml)
             except:
                 c.text = self.content
-                pass  # Keep calm and carry on
         else:
             c.text = self.content
 


### PR DESCRIPTION
If set to a (byte-)string (`str` type in Python), attempt to decode it as UTF-8. Otherwise, users of libtaxii should pass in a unicode object directly.

This is necessary when passing in serialized UTF-8 XML that has been saved as a Python `str` (for instance, the output of `STIXPackage.to_xml()`, when that content contains non-ASCII characters.)
