### PR TITLE
Removing in_response_to argument in Request classes

### DIFF
--- a/libtaxii/common.py
+++ b/libtaxii/common.py
@@ -8,8 +8,10 @@ from StringIO import StringIO
 from re import sub as resub
 import dateutil.parser
 import random
-
+from libtaxii.constants import VID_TAXII_SERVICES_10, VID_TAXII_SERVICES_11
 from lxml import etree
+from uuid import uuid4
+import sys
 
 _XML_PARSER = None
 
@@ -77,7 +79,7 @@ def parse_datetime_string(datetime_string):
     return dateutil.parser.parse(datetime_string)
 
 
-def generate_message_id(maxlen=5):
+def generate_message_id(maxlen=5, version=VID_TAXII_SERVICES_10):
     """Generate a TAXII Message ID.
 
     Args:
@@ -91,8 +93,13 @@ def generate_message_id(maxlen=5):
             # Or...
             message = tm11.DiscoveryRequest(tm11.generate_message_id())
     """
-    message_id = random.randint(1, 10 ** maxlen)
-    return str(message_id)
+    if version == VID_TAXII_SERVICES_10:
+        message_id = str(uuid4().int % sys.maxint)
+    elif version == VID_TAXII_SERVICES_11:
+        message_id = str(uuid4())
+    else:
+        raise ValueError('Unknown TAXII Version: %s. Must be a TAXII Services Version ID!', version)
+    return message_id
 
 
 def append_any_content_etree(etree_elt, content):

--- a/libtaxii/messages_10.py
+++ b/libtaxii/messages_10.py
@@ -1592,7 +1592,7 @@ class PollRequest(TAXIIMessage):
     """
     message_type = MSG_POLL_REQUEST
 
-    def __init__(self, message_id, in_response_to=None, extended_headers=None,
+    def __init__(self, message_id, extended_headers=None,
                  feed_name=None, exclusive_begin_timestamp_label=None,
                  inclusive_end_timestamp_label=None, subscription_id=None,
                  content_bindings=None):

--- a/libtaxii/messages_10.py
+++ b/libtaxii/messages_10.py
@@ -450,6 +450,8 @@ class TAXIIMessage(TAXIIBase10):
 
         # Get in response to, if present
         in_response_to = get_optional(src_etree, '/taxii:*/@in_response_to', ns_map)
+        if in_response_to:
+            kwargs['in_response_to'] = in_response_to
 
         # Get the Extended headers
         extended_header_list = src_etree.xpath('/taxii:*/taxii:Extended_Headers/taxii:Extended_Header', namespaces=ns_map)
@@ -464,7 +466,7 @@ class TAXIIMessage(TAXIIBase10):
 
             extended_headers[eh_name] = eh_value
 
-        return cls(message_id, in_response_to, extended_headers=extended_headers, **kwargs)
+        return cls(message_id, extended_headers=extended_headers, **kwargs)
 
 
     @classmethod
@@ -503,11 +505,10 @@ class TAXIIMessage(TAXIIBase10):
             extended_headers[k] = v
 
         in_response_to = d.get('in_response_to')
+        if in_response_to:
+            kwargs['in_response_to'] = in_response_to
 
-        return cls(message_id,
-                   in_response_to,
-                   extended_headers=extended_headers,
-                   **kwargs)
+        return cls(message_id, extended_headers=extended_headers, **kwargs)
 
     @classmethod
     def from_json(cls, json_string):
@@ -2305,7 +2306,7 @@ class ManageFeedSubscriptionRequest(TAXIIMessage):
 
     message_type = MSG_MANAGE_FEED_SUBSCRIPTION_REQUEST
 
-    def __init__(self, message_id, in_response_to=None, extended_headers=None,
+    def __init__(self, message_id, extended_headers=None,
                  feed_name=None, action=None, subscription_id=None,
                  delivery_parameters=None):
         super(ManageFeedSubscriptionRequest, self).__init__(message_id, extended_headers=extended_headers)

--- a/libtaxii/messages_11.py
+++ b/libtaxii/messages_11.py
@@ -1113,6 +1113,8 @@ class TAXIIMessage(TAXIIBase11):
 
         # Get in response to, if present
         in_response_to = get_optional(src_etree, '/taxii_11:*/@in_response_to', ns_map)
+        if in_response_to:
+            kwargs['in_response_to'] = in_response_to
 
         # Get the Extended headers
         extended_header_list = src_etree.xpath('/taxii_11:*/taxii_11:Extended_Headers/taxii_11:Extended_Header', namespaces=ns_map)
@@ -1126,7 +1128,7 @@ class TAXIIMessage(TAXIIBase11):
 
             extended_headers[eh_name] = eh_value
 
-        return cls(message_id, in_response_to, extended_headers=extended_headers, **kwargs)
+        return cls(message_id, extended_headers=extended_headers, **kwargs)
 
 
     @classmethod
@@ -1150,11 +1152,10 @@ class TAXIIMessage(TAXIIBase11):
             extended_headers[k] = v
 
         in_response_to = d.get('in_response_to')
+        if in_response_to:
+            kwargs['in_response_to'] = in_response_to
 
-        return cls(message_id,
-                   in_response_to,
-                   extended_headers=extended_headers,
-                   **kwargs)
+        return cls(message_id, extended_headers=extended_headers, **kwargs)
 
     @classmethod
     def from_json(cls, json_string):
@@ -2331,7 +2332,7 @@ class PollRequest(TAXIIRequestMessage):
     """
     message_type = MSG_POLL_REQUEST
 
-    def __init__(self, message_id, in_response_to=None, extended_headers=None,
+    def __init__(self, message_id, extended_headers=None,
                  collection_name=None, exclusive_begin_timestamp_label=None,
                  inclusive_end_timestamp_label=None, subscription_id=None,
                  poll_parameters=None):
@@ -3442,7 +3443,7 @@ class ManageCollectionSubscriptionRequest(TAXIIRequestMessage):
 
     message_type = MSG_MANAGE_COLLECTION_SUBSCRIPTION_REQUEST
 
-    def __init__(self, message_id, in_response_to=None, extended_headers=None,
+    def __init__(self, message_id, extended_headers=None,
                  collection_name=None, action=None, subscription_id=None,
                  subscription_parameters=None, push_parameters=None):
 
@@ -3977,7 +3978,7 @@ class PollFulfillmentRequest(TAXIIRequestMessage):
     """
     message_type = MSG_POLL_FULFILLMENT_REQUEST
 
-    def __init__(self, message_id, in_response_to=None, extended_headers=None,
+    def __init__(self, message_id, extended_headers=None,
                  collection_name=None, result_id=None, result_part_number=None):
         super(PollFulfillmentRequest, self).__init__(message_id, extended_headers=extended_headers)
         self.collection_name = collection_name

--- a/libtaxii/messages_11.py
+++ b/libtaxii/messages_11.py
@@ -1277,7 +1277,7 @@ class ServiceInstance(TAXIIBase11):
             TAXII Daemon that hosts this Service. **Required**
         message_bindings (list of strings): identifies the message
             bindings supported by this Service instance. **Required**
-        inbox_service_accepted_content (list of strings): identifies
+        inbox_service_accepted_content (list of ContentBinding objects): identifies
             content bindings that this Inbox Service is willing to accept.
             **Optional**
         available (boolean): indicates whether the identity of the


### PR DESCRIPTION
The objective of this pull request is to remove unused and illogical constructor argument `in_response_to` from Request classes: `PollRequest`, `ManageFeedSubscriptionRequest`, `ManageCollectionSubscriptionRequest` and `PollFulfillmentRequest`.

This argument was not used there in any way.