### PR TITLE
Delivery Parameters field in Subscription Instance can not have multiple values (TAXII 1.0)

### DIFF
--- a/libtaxii/messages_11.py
+++ b/libtaxii/messages_11.py
@@ -598,8 +598,12 @@ class _GenericParameters(TAXIIBase11):
         s = line_prepend + "=== %s ===\n" % self.name
         for binding in self.content_bindings:
             s += "  Content Binding: %s\n" % str(binding)
+
         if self.query:
             s += self.query.to_text(line_prepend + STD_INDENT)
+
+        if self.response_type:
+            s += line_prepend + "  Response type: %s\n" % str(self.response_type)
 
         return s
 

--- a/libtaxii/test/messages_10_test.py
+++ b/libtaxii/test/messages_10_test.py
@@ -478,7 +478,7 @@ class ManageFeedSubscriptionResponseTests(unittest.TestCase):
 
         subscription_instance1 = tm10.SubscriptionInstance(
             subscription_id='SubsId234',  # required
-            delivery_parameters=[delivery_parameters1],  # Required if message is responding to a status action. Optional otherwise
+            delivery_parameters=delivery_parameters1,  # Required if message is responding to a status action. Optional otherwise
             poll_instances=[poll_instance1])  # Required if action was polling subscription. Optional otherwise
 
         manage_feed_subscription_response1 = tm10.ManageFeedSubscriptionResponse(
@@ -502,7 +502,7 @@ class ManageFeedSubscriptionResponseTests(unittest.TestCase):
 
         subscription = tm10.ManageFeedSubscriptionResponse.SubscriptionInstance(
             subscription_id='SubsId234',
-            delivery_parameters=[delivery_parameters1],
+            delivery_parameters=delivery_parameters1,
             poll_instances=[poll])
 
         response = tm10.ManageFeedSubscriptionResponse(


### PR DESCRIPTION
According to the specification, there can be only one (or none) instance of Delivery Parameters in Subscription Instance (TAXII Services Specification 1.0, 3.4.7 TAXII Manage Feed Subscription Response).

In this pull request lines where `delivery_parameters` field of `tm10.SubscriptionInstance` is treated as list were refactored.