### PR TITLE
Make libtaxii compatible with Python 2 and 3

### DIFF
--- a/libtaxii/__init__.py
+++ b/libtaxii/__init__.py
@@ -9,8 +9,7 @@
 The main libtaxii module
 """
 
-
-import six.moves.http_client
+import six
 from six.moves import urllib
 
 import libtaxii.messages_10 as tm10
@@ -19,7 +18,7 @@ import libtaxii.clients as tc
 from .constants import *
 
 from .version import __version__  # noqa
-import six
+
 
 def get_message_from_http_response(http_response, in_response_to):
     """Create a TAXII message from an HTTPResponse object.

--- a/libtaxii/__init__.py
+++ b/libtaxii/__init__.py
@@ -12,8 +12,6 @@ The main libtaxii module
 
 import six.moves.http_client
 from six.moves import urllib
-import urllib.request, urllib.parse, urllib.error
-import urllib.request, urllib.error, urllib.parse
 
 import libtaxii.messages_10 as tm10
 import libtaxii.messages_11 as tm11
@@ -48,7 +46,7 @@ def get_message_from_http_response(http_response, in_response_to):
         return get_message_from_httplib_http_response(http_response, in_response_to)
     elif isinstance(http_response, urllib.error.HTTPError):
         return get_message_from_urllib2_httperror(http_response, in_response_to)
-    elif isinstance(http_response, urllib.addinfourl):
+    elif isinstance(http_response, urllib.response.addinfourl):
         return get_message_from_urllib_addinfourl(http_response, in_response_to)
     else:
         raise ValueError('Unsupported response type: %s.' % http_response.__class__.__name__)

--- a/libtaxii/__init__.py
+++ b/libtaxii/__init__.py
@@ -8,12 +8,12 @@
 """
 The main libtaxii module
 """
-from __future__ import absolute_import
+
 
 import six.moves.http_client
 from six.moves import urllib
-import urllib
-import urllib2
+import urllib.request, urllib.parse, urllib.error
+import urllib.request, urllib.error, urllib.parse
 
 import libtaxii.messages_10 as tm10
 import libtaxii.messages_11 as tm11
@@ -46,7 +46,7 @@ def get_message_from_http_response(http_response, in_response_to):
     """
     if isinstance(http_response, six.moves.http_client.HTTPResponse):
         return get_message_from_httplib_http_response(http_response, in_response_to)
-    elif isinstance(http_response, urllib2.HTTPError):
+    elif isinstance(http_response, urllib.error.HTTPError):
         return get_message_from_urllib2_httperror(http_response, in_response_to)
     elif isinstance(http_response, urllib.addinfourl):
         return get_message_from_urllib_addinfourl(http_response, in_response_to)

--- a/libtaxii/__init__.py
+++ b/libtaxii/__init__.py
@@ -8,8 +8,10 @@
 """
 The main libtaxii module
 """
+from __future__ import absolute_import
 
-import httplib
+import six.moves.http_client
+from six.moves import urllib
 import urllib
 import urllib2
 
@@ -19,6 +21,7 @@ import libtaxii.clients as tc
 from .constants import *
 
 from .version import __version__  # noqa
+import six
 
 def get_message_from_http_response(http_response, in_response_to):
     """Create a TAXII message from an HTTPResponse object.
@@ -41,7 +44,7 @@ def get_message_from_http_response(http_response, in_response_to):
             parse
         in_reponse_to (str): the default value for in_response_to
     """
-    if isinstance(http_response, httplib.HTTPResponse):
+    if isinstance(http_response, six.moves.http_client.HTTPResponse):
         return get_message_from_httplib_http_response(http_response, in_response_to)
     elif isinstance(http_response, urllib2.HTTPError):
         return get_message_from_urllib2_httperror(http_response, in_response_to)
@@ -79,7 +82,7 @@ def get_message_from_urllib_addinfourl(http_response, in_response_to):
     if taxii_content_type is None:  # Treat it as a Failure Status Message, per the spec
 
         message = []
-        header_dict = http_response.info().dict.iteritems()
+        header_dict = six.iteritems(http_response.info().dict)
         for k, v in header_dict:
             message.append(k + ': ' + v + '\r\n')
         message.append('\r\n')

--- a/libtaxii/clients.py
+++ b/libtaxii/clients.py
@@ -8,8 +8,9 @@
 """
 TAXII Clients
 """
+from __future__ import absolute_import
 
-import httplib
+import six.moves.http_client
 import urllib
 import urllib2
 import base64
@@ -17,6 +18,7 @@ import socket
 import ssl
 import warnings
 from libtaxii.constants import *
+import six
 
 
 class HttpClient(object):
@@ -167,26 +169,26 @@ class HttpClient(object):
         if self.use_https:
             header_dict['X-TAXII-Protocol'] = VID_TAXII_HTTPS_10
             if self.auth_type == HttpClient.AUTH_NONE:
-                conn = httplib.HTTPSConnection(host, port)
+                conn = six.moves.http_client.HTTPSConnection(host, port)
             elif self.auth_type == HttpClient.AUTH_BASIC:
                 header_dict['Authorization'] = self.basic_auth_header
-                conn = httplib.HTTPSConnection(host, port)
+                conn = six.moves.http_client.HTTPSConnection(host, port)
             else:  # AUTH_CERT
                 key_file = self.auth_credentials['key_file']
                 cert_file = self.auth_credentials['cert_file']
-                conn = httplib.HTTPSConnection(host, port, key_file, cert_file)
+                conn = six.moves.http_client.HTTPSConnection(host, port, key_file, cert_file)
         else:  # Not using https
             header_dict['X-TAXII-Protocol'] = VID_TAXII_HTTP_10
             if self.auth_type == HttpClient.AUTH_NONE:
-                conn = httplib.HTTPConnection(host, port)
+                conn = six.moves.http_client.HTTPConnection(host, port)
             # TODO: Consider deleting because this is a terrible idea
             elif self.auth_type == HttpClient.AUTH_BASIC:  # Sending credentials in cleartext.. tsk tsk
                 header_dict['Authorization'] = self.basic_auth_header
-                conn = httplib.HTTPConnection(host, port)
+                conn = six.moves.http_client.HTTPConnection(host, port)
             else:  # AUTH_CERT
                 key_file = self.auth_credentials['key_file']
                 cert_file = self.auth_credentials['cert_file']
-                conn = httplib.HTTPConnection(host, port, key_file, cert_file)
+                conn = six.moves.http_client.HTTPConnection(host, port, key_file, cert_file)
 
         header_dict['Content-Type'] = 'application/xml'
         header_dict['X-TAXII-Content-Type'] = message_binding
@@ -209,7 +211,7 @@ class HttpClient(object):
         header_dict = {}
 
         if headers is not None:
-            for k, v in headers.iteritems():
+            for k, v in six.iteritems(headers):
                 header_dict[k.lower()] = v
 
         header_dict['User-Agent'] = 'libtaxii.httpclient'
@@ -337,7 +339,7 @@ class HttpClient(object):
         try:
             response = urllib2.urlopen(req)
             return response
-        except urllib2.HTTPError, error:
+        except urllib2.HTTPError as error:
             return error
 
     # Backwards compatibility
@@ -382,10 +384,10 @@ class HTTPClientAuthHandler(urllib2.HTTPSHandler):  # TODO: Is this used / is th
         return self.do_open(self.get_connection, req)
 
     def get_connection(self, host, timeout=0):
-        return httplib.HTTPSConnection(host, key_file=self.key, cert_file=self.cert, timeout=timeout)
+        return six.moves.http_client.HTTPSConnection(host, key_file=self.key, cert_file=self.cert, timeout=timeout)
 
 
-class VerifiableHTTPSConnection(httplib.HTTPSConnection):
+class VerifiableHTTPSConnection(six.moves.http_client.HTTPSConnection):
 
     """
     The default httplib HTTPSConnection does not verify certificates.
@@ -396,7 +398,7 @@ class VerifiableHTTPSConnection(httplib.HTTPSConnection):
     def __init__(self, host, port=None, key_file=None, cert_file=None,
                  strict=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
                  source_address=None, verify_server=False, ca_certs=None):
-        httplib.HTTPSConnection.__init__(self, host, port, key_file,
+        six.moves.http_client.HTTPSConnection.__init__(self, host, port, key_file,
                                          cert_file, strict, timeout,
                                          source_address)
 

--- a/libtaxii/clients.py
+++ b/libtaxii/clients.py
@@ -11,14 +11,13 @@ TAXII Clients
 
 
 import six.moves.http_client
-import urllib.request, urllib.parse, urllib.error
-import urllib.request, urllib.error, urllib.parse
 import base64
 import socket
 import ssl
 import warnings
 from libtaxii.constants import *
 import six
+from six.moves import urllib
 
 
 class HttpClient(object):

--- a/libtaxii/clients.py
+++ b/libtaxii/clients.py
@@ -8,11 +8,11 @@
 """
 TAXII Clients
 """
-from __future__ import absolute_import
+
 
 import six.moves.http_client
-import urllib
-import urllib2
+import urllib.request, urllib.parse, urllib.error
+import urllib.request, urllib.error, urllib.parse
 import base64
 import socket
 import ssl
@@ -158,7 +158,7 @@ class HttpClient(object):
                 port = 80
 
         if get_params_dict is not None:  # Add the query params to the URL
-            path += '?' + urllib.urlencode(get_params_dict)
+            path += '?' + urllib.parse.urlencode(get_params_dict)
 
         header_dict = {'Content-Type': 'application/xml',
                        'User-Agent': 'libtaxii.httpclient'}
@@ -296,7 +296,7 @@ class HttpClient(object):
             header_dict[HttpClient.HEADER_X_TAXII_PROTOCOL] = VID_TAXII_HTTP_10
 
             if self.auth_type == HttpClient.AUTH_NONE:
-                handler_list.append(urllib2.HTTPHandler())
+                handler_list.append(urllib.request.HTTPHandler())
             elif self.auth_type == HttpClient.AUTH_BASIC:
                 header_dict['Authorization'] = self.basic_auth_header
             elif self.auth_type == HttpClient.AUTH_CERT:
@@ -308,17 +308,17 @@ class HttpClient(object):
                 k = self.auth_credentials['key_file']
                 c = self.auth_credentials['cert_file']
                 handler_list.append(HTTPSClientAuthHandler(k, c))
-            handler_list.append(urllib2.HTTPHandler())
+            handler_list.append(urllib.request.HTTPHandler())
 
         if self.proxy_string is not None:
             if self.proxy_string == 'noproxy':
                 # Dont use any proxy, including the system-specified proxy
-                handler_list.append(urllib2.ProxyHandler({}))
+                handler_list.append(urllib.request.ProxyHandler({}))
             else:  # Use a specific proxy
-                handler_list.append(urllib2.ProxyHandler({self.PROXY_HTTP: self.proxy_string, self.PROXY_HTTPS: self.proxy_string}))
+                handler_list.append(urllib.request.ProxyHandler({self.PROXY_HTTP: self.proxy_string, self.PROXY_HTTPS: self.proxy_string}))
 
-        opener = urllib2.build_opener(*handler_list)
-        urllib2.install_opener(opener)
+        opener = urllib.request.build_opener(*handler_list)
+        urllib.request.install_opener(opener)
 
         if port is None:  # If the caller did not specify a port, use the default
             if self.use_https:
@@ -333,13 +333,13 @@ class HttpClient(object):
 
         url = scheme + host + ':' + str(port) + path
         if get_params_dict is not None:
-            url += '?' + urllib.urlencode(get_params_dict)
+            url += '?' + urllib.parse.urlencode(get_params_dict)
 
-        req = urllib2.Request(url, post_data, header_dict)
+        req = urllib.request.Request(url, post_data, header_dict)
         try:
-            response = urllib2.urlopen(req)
+            response = urllib.request.urlopen(req)
             return response
-        except urllib2.HTTPError as error:
+        except urllib.error.HTTPError as error:
             return error
 
     # Backwards compatibility
@@ -353,10 +353,10 @@ class HttpClient(object):
 
 
 # http://stackoverflow.com/questions/5896380/https-connection-using-pem-certificate
-class LibtaxiiHTTPSHandler(urllib2.HTTPSHandler):
+class LibtaxiiHTTPSHandler(urllib.request.HTTPSHandler):
 
     def __init__(self, key_file=None, cert_file=None, verify_server=False, ca_certs=None):
-        urllib2.HTTPSHandler.__init__(self)
+        urllib.request.HTTPSHandler.__init__(self)
         self.key_file = key_file
         self.cert_file = cert_file
         self.verify_server = verify_server
@@ -373,10 +373,10 @@ class LibtaxiiHTTPSHandler(urllib2.HTTPSHandler):
                                          ca_certs=self.ca_certs)
 
 
-class HTTPClientAuthHandler(urllib2.HTTPSHandler):  # TODO: Is this used / is this possible?
+class HTTPClientAuthHandler(urllib.request.HTTPSHandler):  # TODO: Is this used / is this possible?
 
     def __init__(self, key, cert):
-        urllib2.HTTPSHandler.__init__(self)
+        urllib.request.HTTPSHandler.__init__(self)
         self.key = key
         self.cert = cert
 

--- a/libtaxii/clients.py
+++ b/libtaxii/clients.py
@@ -9,8 +9,6 @@
 TAXII Clients
 """
 
-
-import six.moves.http_client
 import base64
 import socket
 import ssl

--- a/libtaxii/common.py
+++ b/libtaxii/common.py
@@ -40,6 +40,21 @@ def parse(s):
     return e
 
 
+def parse_xml_string(xmlstr):
+    """Parse an XML string (binary or unicode) with the default parser.
+
+    :param xmlstr: An XML String to parse
+    :return: an etree._Element
+    """
+    if isinstance(xmlstr, six.binary_type):
+        xmlstr = six.BytesIO(xmlstr)
+    elif isinstance(xmlstr, six.text_type):
+        xmlstr = six.StringIO(xmlstr)
+
+    return parse(xmlstr)
+
+
+
 def get_xml_parser():
     """Return the XML parser currently in use.
 
@@ -249,12 +264,7 @@ class TAXIIBase(object):
 
         Subclasses should not need to implement this method.
         """
-        if isinstance(xml, six.string_types):
-            xmlstr = six.BytesIO(xml)
-        else:
-            xmlstr = xml
-
-        etree_xml = parse(xmlstr)
+        etree_xml = parse_xml_string(xml)
         return cls.from_etree(etree_xml)
 
     # Just noting that there is not a from_text() method. I also

--- a/libtaxii/common.py
+++ b/libtaxii/common.py
@@ -2,11 +2,11 @@
 Common utility classes and functions used throughout libtaxii.
 
 """
-from __future__ import absolute_import
-from __future__ import print_function
+
+
 
 from operator import attrgetter
-from StringIO import StringIO
+from io import StringIO
 from re import sub as resub
 import dateutil.parser
 import random
@@ -98,7 +98,7 @@ def generate_message_id(maxlen=5, version=VID_TAXII_SERVICES_10):
             message = tm11.DiscoveryRequest(tm11.generate_message_id())
     """
     if version == VID_TAXII_SERVICES_10:
-        message_id = str(uuid4().int % sys.maxint)
+        message_id = str(uuid4().int % sys.maxsize)
     elif version == VID_TAXII_SERVICES_11:
         message_id = str(uuid4())
     else:

--- a/libtaxii/common.py
+++ b/libtaxii/common.py
@@ -6,7 +6,6 @@ Common utility classes and functions used throughout libtaxii.
 
 
 from operator import attrgetter
-from io import StringIO
 from re import sub as resub
 import dateutil.parser
 import random
@@ -233,7 +232,7 @@ class TAXIIBase(object):
         Subclasses should not need to implement this method.
         """
         if isinstance(xml, six.string_types):
-            xmlstr = StringIO(xml)
+            xmlstr = six.BytesIO(xml)
         else:
             xmlstr = xml
 

--- a/libtaxii/common.py
+++ b/libtaxii/common.py
@@ -14,7 +14,7 @@ from lxml import etree
 from uuid import uuid4
 import sys
 import six
-from six.moves import zip
+
 try:
     import simplejson as json
 except ImportError:
@@ -320,7 +320,7 @@ class TAXIIBase(object):
                         # All TAXIIBase objects have the 'sort_key' property implemented
                         self_value = sorted(self_value, key=attrgetter('sort_key'))
                         other_value = sorted(other_value, key=attrgetter('sort_key'))
-                        for self_item, other_item in zip(self_value, other_value):
+                        for self_item, other_item in six.moves.zip(self_value, other_value):
                             # Compare the ordered lists element by element
                             eq = self_item.__eq__(other_item, debug)
                     else:

--- a/libtaxii/common.py
+++ b/libtaxii/common.py
@@ -15,6 +15,11 @@ from uuid import uuid4
 import sys
 import six
 from six.moves import zip
+try:
+    import simplejson as json
+except ImportError:
+    import json
+
 
 _XML_PARSER = None
 
@@ -191,6 +196,13 @@ class TAXIIBase(object):
         """
         raise NotImplementedError()
 
+    def to_json(self):
+        """Create a JSON object of this class.
+
+        Assumes any binary content will be UTF-8 encoded.
+        """
+        raise NotImplementedError()
+
     def to_xml(self, pretty_print=False):
         """Create an XML representation of this class.
 
@@ -357,4 +369,3 @@ def get_optional_text(etree_xml, xpath, ns_map):
         return get_required(etree_xml, xpath, ns_map).text
     except ValueError:
         pass
-

--- a/libtaxii/common.py
+++ b/libtaxii/common.py
@@ -218,9 +218,7 @@ class TAXIIBase(object):
         """
         content_dict = self.to_dict()
 
-        for k, v in content_dict.items():
-            if isinstance(v, six.binary_type):
-                content_dict[k] = v.decode('utf-8')
+        _decode_binary_fields(content_dict)
 
         return json.dumps(content_dict)
 
@@ -380,8 +378,23 @@ def get_optional(etree_xml, xpath, ns_map):
     except ValueError:
         pass
 
+
 def get_optional_text(etree_xml, xpath, ns_map):
     try:
         return get_required(etree_xml, xpath, ns_map).text
     except ValueError:
         pass
+
+
+def _decode_binary_fields(dict_obj):
+    """Given a dict, decode any binary values, assuming UTF-8 encoding.
+    Will recurse into nested dicts.
+    Modifies the values in-place.
+    """
+    for key, value in dict_obj.items():
+
+        if isinstance(value, six.binary_type):
+            dict_obj[key] = value.decode('utf-8')
+
+        elif isinstance(value, dict):
+            _decode_binary_fields(value)

--- a/libtaxii/common.py
+++ b/libtaxii/common.py
@@ -201,7 +201,13 @@ class TAXIIBase(object):
 
         Assumes any binary content will be UTF-8 encoded.
         """
-        raise NotImplementedError()
+        content_dict = self.to_dict()
+
+        for k, v in content_dict.items():
+            if isinstance(v, six.binary_type):
+                content_dict[k] = v.decode('utf-8')
+
+        return json.dumps(content_dict)
 
     def to_xml(self, pretty_print=False):
         """Create an XML representation of this class.

--- a/libtaxii/common.py
+++ b/libtaxii/common.py
@@ -2,6 +2,8 @@
 Common utility classes and functions used throughout libtaxii.
 
 """
+from __future__ import absolute_import
+from __future__ import print_function
 
 from operator import attrgetter
 from StringIO import StringIO
@@ -12,6 +14,8 @@ from libtaxii.constants import *
 from lxml import etree
 from uuid import uuid4
 import sys
+import six
+from six.moves import zip
 
 _XML_PARSER = None
 
@@ -124,7 +128,7 @@ def append_any_content_etree(etree_elt, content):
         etree_elt.append(content)
         return etree_elt
 
-    if not isinstance(content, basestring):  # If content is a non-string, cast it to string and set etree_elt.text
+    if not isinstance(content, six.string_types):  # If content is a non-string, cast it to string and set etree_elt.text
         etree_elt.text = str(content)
         return etree_elt
 
@@ -228,7 +232,7 @@ class TAXIIBase(object):
 
         Subclasses should not need to implement this method.
         """
-        if isinstance(xml, basestring):
+        if isinstance(xml, six.string_types):
             xmlstr = StringIO(xml)
         else:
             xmlstr = xml
@@ -261,19 +265,19 @@ class TAXIIBase(object):
         """
         if other is None:
             if debug:
-                print 'other was None!'
+                print('other was None!')
             return False
 
         if self.__class__.__name__ != other.__class__.__name__:
             if debug:
-                print 'class names not equal: %s != %s' % (self.__class__.__name__, other.__class__.__name__)
+                print('class names not equal: %s != %s' % (self.__class__.__name__, other.__class__.__name__))
             return False
 
         # Get all member properties that start with '_'
         members = [attr for attr in vars(self) if attr.startswith('_') and not attr.startswith('__')]
         for member in members:
             if debug:
-                print 'member name: %s' % member
+                print('member name: %s' % member)
             self_value = getattr(self, member)
             other_value = getattr(other, member)
 
@@ -309,12 +313,12 @@ class TAXIIBase(object):
                 # Dictionary to compare
                 if len(set(self_value.keys()) - set(other_value.keys())) != 0:
                     if debug:
-                        print 'dict keys not equal: %s != %s' % (self_value, other_value)
+                        print('dict keys not equal: %s != %s' % (self_value, other_value))
                     eq = False
-                for k, v in self_value.iteritems():
+                for k, v in six.iteritems(self_value):
                     if other_value[k] != v:
                         if debug:
-                            print 'dict values not equal: %s != %s' % (v, other_value[k])
+                            print('dict values not equal: %s != %s' % (v, other_value[k]))
                         eq = False
                 eq = True
             elif isinstance(self_value, etree._Element):
@@ -327,7 +331,7 @@ class TAXIIBase(object):
             # TODO: is this duplicate?
             if not eq:
                 if debug:
-                    print '%s was not equal: %s != %s' % (member, self_value, other_value)
+                    print('%s was not equal: %s != %s' % (member, self_value, other_value))
                 return False
 
         return True

--- a/libtaxii/messages.py
+++ b/libtaxii/messages.py
@@ -8,5 +8,6 @@ was added (in messages_11.py), the contents of this file were moved to
 messages_10.py. This file allows existing code (referring to libtaxii.messages)
 to continue working as before.
 """
+from __future__ import absolute_import
 
 from libtaxii.messages_10 import *

--- a/libtaxii/messages.py
+++ b/libtaxii/messages.py
@@ -8,6 +8,6 @@ was added (in messages_11.py), the contents of this file were moved to
 messages_10.py. This file allows existing code (referring to libtaxii.messages)
 to continue working as before.
 """
-from __future__ import absolute_import
+
 
 from libtaxii.messages_10 import *

--- a/libtaxii/messages_10.py
+++ b/libtaxii/messages_10.py
@@ -10,7 +10,7 @@
 """
 Creating, handling, and parsing TAXII 1.0 messages.
 """
-from __future__ import absolute_import
+
 import six
 
 try:
@@ -18,7 +18,7 @@ try:
 except ImportError:
     import json
 import os
-import StringIO
+import io
 import warnings
 
 from lxml import etree
@@ -49,7 +49,7 @@ def validate_xml(xml_string):
                   category=DeprecationWarning)
 
     if isinstance(xml_string, six.string_types):
-        f = StringIO.StringIO(xml_string)
+        f = io.StringIO(xml_string)
     else:
         f = xml_string
 
@@ -80,7 +80,7 @@ def get_message_from_xml(xml_string):
             new_message = tm10.get_message_from_xml(message_xml)
     """
     if isinstance(xml_string, six.string_types):
-        f = StringIO.StringIO(xml_string)
+        f = io.StringIO(xml_string)
     else:
         f = xml_string
 
@@ -479,7 +479,7 @@ class TAXIIMessage(TAXIIBase10):
         for cls.from_etree.
         """
         if isinstance(xml, six.string_types):
-            f = StringIO.StringIO(xml)
+            f = io.StringIO(xml)
         else:
             f = xml
 
@@ -603,7 +603,7 @@ class ContentBlock(TAXIIBase10):
                 return content.read(), False
         else:  # The Content is not file-like
             try:  # Attempt to parse string as XML
-                sio_content = StringIO.StringIO(content)
+                sio_content = io.StringIO(content)
                 xml = parse(sio_content)
                 return xml, True
             except etree.XMLSyntaxError:  # Content is not well-formed XML; just treat as a string

--- a/libtaxii/messages_10.py
+++ b/libtaxii/messages_10.py
@@ -417,9 +417,6 @@ class TAXIIMessage(TAXIIBase10):
 
         return d
 
-    def to_json(self):
-        return json.dumps(self.to_dict())
-
     def to_text(self, line_prepend=''):
         s = line_prepend + "Message Type: %s\n" % self.message_type
         s += line_prepend + "Message ID: %s" % self.message_id
@@ -650,9 +647,6 @@ class ContentBlock(TAXIIBase10):
 
         return block
 
-    def to_json(self):
-        return json.dumps(self.to_dict())
-
     def to_text(self, line_prepend=''):
         s = line_prepend + "=== Content Block ===\n"
         s += line_prepend + "  Content Binding: %s\n" % self.content_binding
@@ -778,9 +772,6 @@ class DiscoveryResponse(TAXIIMessage):
         for service_instance in self.service_instances:
             d['service_instances'].append(service_instance.to_dict())
         return d
-
-    def to_json(self):
-        return json.dumps(self.to_dict())
 
     def to_text(self, line_prepend=''):
         s = super(DiscoveryResponse, self).to_text(line_prepend)

--- a/libtaxii/messages_10.py
+++ b/libtaxii/messages_10.py
@@ -18,7 +18,6 @@ try:
 except ImportError:
     import json
 import os
-import io
 import warnings
 
 from lxml import etree
@@ -49,7 +48,7 @@ def validate_xml(xml_string):
                   category=DeprecationWarning)
 
     if isinstance(xml_string, six.string_types):
-        f = io.StringIO(xml_string)
+        f = six.BytesIO(xml_string)
     else:
         f = xml_string
 
@@ -80,7 +79,7 @@ def get_message_from_xml(xml_string):
             new_message = tm10.get_message_from_xml(message_xml)
     """
     if isinstance(xml_string, six.string_types):
-        f = io.StringIO(xml_string)
+        f = six.BytesIO(xml_string)
     else:
         f = xml_string
 
@@ -479,7 +478,7 @@ class TAXIIMessage(TAXIIBase10):
         for cls.from_etree.
         """
         if isinstance(xml, six.string_types):
-            f = io.StringIO(xml)
+            f = six.BytesIO(xml)
         else:
             f = xml
 
@@ -603,7 +602,7 @@ class ContentBlock(TAXIIBase10):
                 return content.read(), False
         else:  # The Content is not file-like
             try:  # Attempt to parse string as XML
-                sio_content = io.StringIO(content)
+                sio_content = six.StringIO(content)
                 xml = parse(sio_content)
                 return xml, True
             except etree.XMLSyntaxError:  # Content is not well-formed XML; just treat as a string

--- a/libtaxii/messages_10.py
+++ b/libtaxii/messages_10.py
@@ -10,6 +10,8 @@
 """
 Creating, handling, and parsing TAXII 1.0 messages.
 """
+from __future__ import absolute_import
+import six
 
 try:
     import simplejson as json
@@ -24,7 +26,7 @@ from lxml import etree
 from .common import (parse, parse_datetime_string, append_any_content_etree, TAXIIBase,
         get_required, get_optional, get_optional_text)
 from .validation import do_check, uri_regex, check_timestamp_label, message_id_regex_10
-from constants import *
+from .constants import *
 
 
 def validate_xml(xml_string):
@@ -46,7 +48,7 @@ def validate_xml(xml_string):
     warnings.warn('Call to deprecated function: libtaxii.messages_10.validate_xml()',
                   category=DeprecationWarning)
 
-    if isinstance(xml_string, basestring):
+    if isinstance(xml_string, six.string_types):
         f = StringIO.StringIO(xml_string)
     else:
         f = xml_string
@@ -77,7 +79,7 @@ def get_message_from_xml(xml_string):
             message_xml = message.to_xml()
             new_message = tm10.get_message_from_xml(message_xml)
     """
-    if isinstance(xml_string, basestring):
+    if isinstance(xml_string, six.string_types):
         f = StringIO.StringIO(xml_string)
     else:
         f = xml_string
@@ -360,7 +362,7 @@ class TAXIIMessage(TAXIIBase10):
 
     @extended_headers.setter
     def extended_headers(self, value):
-        do_check(value.keys(), 'extended_headers.keys()', regex_tuple=uri_regex)
+        do_check(list(value.keys()), 'extended_headers.keys()', regex_tuple=uri_regex)
         self._extended_headers = value
 
     def to_etree(self):
@@ -379,7 +381,7 @@ class TAXIIMessage(TAXIIBase10):
         if len(self.extended_headers) > 0:
             eh = etree.SubElement(root_elt, '{%s}Extended_Headers' % ns_map['taxii'])
 
-            for name, value in self.extended_headers.items():
+            for name, value in list(self.extended_headers.items()):
                 h = etree.SubElement(eh, '{%s}Extended_Header' % ns_map['taxii'])
                 h.attrib['name'] = name
                 append_any_content_etree(h, value)
@@ -407,10 +409,10 @@ class TAXIIMessage(TAXIIBase10):
         if self.in_response_to is not None:
             d['in_response_to'] = self.in_response_to
         d['extended_headers'] = {}
-        for k, v in self.extended_headers.iteritems():
+        for k, v in six.iteritems(self.extended_headers):
             if isinstance(v, etree._Element) or isinstance(v, etree._ElementTree):
                 v = etree.tostring(v)
-            elif not isinstance(v, basestring):
+            elif not isinstance(v, six.string_types):
                 v = str(v)
             d['extended_headers'][k] = v
 
@@ -425,7 +427,7 @@ class TAXIIMessage(TAXIIBase10):
         if self.in_response_to:
             s += "; In Response To: %s" % self.in_response_to
         s += "\n"
-        for k, v in self.extended_headers.iteritems():
+        for k, v in six.iteritems(self.extended_headers):
             s += line_prepend + "Extended Header: %s = %s" % (k, v)
 
         return s
@@ -476,7 +478,7 @@ class TAXIIMessage(TAXIIBase10):
         Subclasses shouldn't implemnet this method, as it is mainly a wrapper
         for cls.from_etree.
         """
-        if isinstance(xml, basestring):
+        if isinstance(xml, six.string_types):
             f = StringIO.StringIO(xml)
         else:
             f = xml
@@ -497,7 +499,7 @@ class TAXIIMessage(TAXIIBase10):
             raise ValueError('%s != %s' % (message_type, cls.message_type))
         message_id = d['message_id']
         extended_headers = {}
-        for k, v in d['extended_headers'].iteritems():
+        for k, v in six.iteritems(d['extended_headers']):
             try:
                 v = parse(v)
             except etree.XMLSyntaxError:
@@ -605,7 +607,7 @@ class ContentBlock(TAXIIBase10):
                 xml = parse(sio_content)
                 return xml, True
             except etree.XMLSyntaxError:  # Content is not well-formed XML; just treat as a string
-                if isinstance(content, basestring):  # It's a string of some kind, unicode or otherwise
+                if isinstance(content, six.string_types):  # It's a string of some kind, unicode or otherwise
                     return content, False
                 else:  # It's some other datatype that needs casting to string
                     return str(content), False
@@ -2761,4 +2763,4 @@ ST_TYPES = ST_TYPES_10
 ACT_TYPES = ACT_TYPES_10
 SVC_TYPES = SVC_TYPES_10
 
-from common import (generate_message_id)
+from .common import (generate_message_id)

--- a/libtaxii/messages_11.py
+++ b/libtaxii/messages_11.py
@@ -24,7 +24,7 @@ import warnings
 from lxml import etree
 
 from .common import (parse, parse_datetime_string, append_any_content_etree, TAXIIBase,
-        get_required, get_optional, get_optional_text)
+                     get_required, get_optional, get_optional_text, parse_xml_string)
 from .validation import do_check, uri_regex, check_timestamp_label
 from .constants import *
 
@@ -48,12 +48,7 @@ def validate_xml(xml_string):
     warnings.warn('Call to deprecated function: libtaxii.messages_11.validate_xml()',
                   category=DeprecationWarning)
 
-    if isinstance(xml_string, six.string_types):
-        f = six.BytesIO(xml_string)
-    else:
-        f = xml_string
-
-    etree_xml = parse(f)
+    etree_xml = parse_xml_string(xml_string)
     package_dir, package_filename = os.path.split(__file__)
     schema_file = os.path.join(package_dir, "xsd", "TAXII_XMLMessageBinding_Schema_11.xsd")
     taxii_schema_doc = parse(schema_file)
@@ -80,12 +75,7 @@ def get_message_from_xml(xml_string):
             message_xml = message.to_xml()
             new_message = tm11.get_message_from_xml(message_xml)
     """
-    if isinstance(xml_string, six.string_types):
-        f = six.BytesIO(xml_string)
-    else:
-        f = xml_string
-
-    etree_xml = parse(f)
+    etree_xml = parse_xml_string(xml_string)
     qn = etree.QName(etree_xml)
     if qn.namespace != ns_map['taxii_11']:
         raise ValueError('Unsupported namespace: %s' % qn.namespace)

--- a/libtaxii/messages_11.py
+++ b/libtaxii/messages_11.py
@@ -10,7 +10,7 @@
 """
 Creating, handling, and parsing TAXII 1.1 messages.
 """
-from __future__ import absolute_import
+
 
 import collections
 import six
@@ -19,7 +19,7 @@ try:
 except ImportError:
     import json
 import os
-import StringIO
+import io
 import warnings
 
 from lxml import etree
@@ -50,7 +50,7 @@ def validate_xml(xml_string):
                   category=DeprecationWarning)
 
     if isinstance(xml_string, six.string_types):
-        f = StringIO.StringIO(xml_string)
+        f = io.StringIO(xml_string)
     else:
         f = xml_string
 
@@ -82,7 +82,7 @@ def get_message_from_xml(xml_string):
             new_message = tm11.get_message_from_xml(message_xml)
     """
     if isinstance(xml_string, six.string_types):
-        f = StringIO.StringIO(xml_string)
+        f = io.StringIO(xml_string)
     else:
         f = xml_string
 
@@ -748,7 +748,7 @@ class ContentBlock(TAXIIBase11):
                 return content.read(), False
         else:  # The Content is not file-like
             try:  # Attempt to parse string as XML
-                sio_content = StringIO.StringIO(content)
+                sio_content = io.StringIO(content)
                 xml = parse(sio_content)
                 return xml, True
             except etree.XMLSyntaxError:  # Content is not well-formed XML; just treat as a string

--- a/libtaxii/messages_11.py
+++ b/libtaxii/messages_11.py
@@ -810,9 +810,6 @@ class ContentBlock(TAXIIBase11):
 
         return block
 
-    def to_json(self):
-        return json.dumps(self.to_dict())
-
     def to_text(self, line_prepend=''):
         s = line_prepend + "=== Content Block ===\n"
         s += line_prepend + "  Content Binding: %s\n" % str(self.content_binding)
@@ -1094,9 +1091,6 @@ class TAXIIMessage(TAXIIBase11):
             s += line_prepend + "Extended Header: %s = %s\n" % (k, v)
 
         return s
-
-    def to_json(self):
-        return json.dumps(self.to_dict())
 
     @classmethod
     def from_etree(cls, src_etree, **kwargs):

--- a/libtaxii/messages_11.py
+++ b/libtaxii/messages_11.py
@@ -19,7 +19,6 @@ try:
 except ImportError:
     import json
 import os
-import io
 import warnings
 
 from lxml import etree
@@ -50,7 +49,7 @@ def validate_xml(xml_string):
                   category=DeprecationWarning)
 
     if isinstance(xml_string, six.string_types):
-        f = io.StringIO(xml_string)
+        f = six.BytesIO(xml_string)
     else:
         f = xml_string
 
@@ -82,7 +81,7 @@ def get_message_from_xml(xml_string):
             new_message = tm11.get_message_from_xml(message_xml)
     """
     if isinstance(xml_string, six.string_types):
-        f = io.StringIO(xml_string)
+        f = six.BytesIO(xml_string)
     else:
         f = xml_string
 
@@ -748,7 +747,7 @@ class ContentBlock(TAXIIBase11):
                 return content.read(), False
         else:  # The Content is not file-like
             try:  # Attempt to parse string as XML
-                sio_content = io.StringIO(content)
+                sio_content = six.StringIO(content)
                 xml = parse(sio_content)
                 return xml, True
             except etree.XMLSyntaxError:  # Content is not well-formed XML; just treat as a string

--- a/libtaxii/scripts/__init__.py
+++ b/libtaxii/scripts/__init__.py
@@ -9,12 +9,13 @@ import sys
 import traceback
 import datetime
 import libtaxii.clients as tc
+import six
 from six.moves.urllib.parse import urlparse
 
 import libtaxii as t
 from libtaxii.common import gen_filename
 from libtaxii.constants import *
-from six.moves import input
+
 
 EXIT_SUCCESS = 0
 EXIT_FAILURE = 1
@@ -208,7 +209,7 @@ class TaxiiScript(object):
         elif file_exists and write_type_ == W_PROMPT:
             var = None
             while var not in ('y', 'n'):
-                var = eval(input("Overwrite file (%s)? (y/n): " % filename))
+                var = six.moves.input("Overwrite file (%s)? (y/n): " % filename)
             if var == 'y':
                 write = True
                 message = MSG_FILE_OVERWRITTEN

--- a/libtaxii/scripts/__init__.py
+++ b/libtaxii/scripts/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file
 
@@ -12,6 +14,7 @@ from urlparse import urlparse
 import libtaxii as t
 from libtaxii.common import gen_filename
 from libtaxii.constants import *
+from six.moves import input
 
 EXIT_SUCCESS = 0
 EXIT_FAILURE = 1
@@ -164,11 +167,11 @@ class TaxiiScript(object):
         """
         Default response handler. Just prints the response
         """
-        print "Response:\n"
+        print("Response:\n")
         if args.xml_output is False:
-            print response.to_text()
+            print(response.to_text())
         else:
-            print response.to_xml(pretty_print=True)
+            print(response.to_xml(pretty_print=True))
 
     def create_client(self, use_https, proxy, cert=None, key=None, username=None, password=None):
         client = tc.HttpClient()
@@ -205,7 +208,7 @@ class TaxiiScript(object):
         elif file_exists and write_type_ == W_PROMPT:
             var = None
             while var not in ('y', 'n'):
-                var = raw_input("Overwrite file (%s)? (y/n): " % filename)
+                var = input("Overwrite file (%s)? (y/n): " % filename)
             if var == 'y':
                 write = True
                 message = MSG_FILE_OVERWRITTEN
@@ -262,7 +265,7 @@ class TaxiiScript(object):
             with open(filename, 'w') as f:
                 f.write(cb.content)
 
-        print "%s%s" % (message, filename)
+        print("%s%s" % (message, filename))
 
     def write_cbs_from_poll_response_11(self, poll_response, dest_dir, write_type_=W_CLOBBER):
         """
@@ -302,7 +305,7 @@ class TaxiiScript(object):
                 with open(filename, 'w') as f:
                     f.write(cb.content)
 
-            print "%s%s" % (message, filename)
+            print("%s%s" % (message, filename))
 
     def create_request_message(self, args):
         """
@@ -326,7 +329,7 @@ class TaxiiScript(object):
         deprecated_arg_used = False
         for arg in deprecated_args:
             if str(getattr(args, arg)) != str(parser._optionals.get_default(arg)):
-                print "WARNING: use of deprecated argument: %s. Use --url instead!" % arg
+                print("WARNING: use of deprecated argument: %s. Use --url instead!" % arg)
                 deprecated_arg_used = True
 
         url_used = getattr(args, 'url') != parser._optionals.get_default('url')
@@ -336,7 +339,7 @@ class TaxiiScript(object):
         if deprecated_arg_used:
             url = "https" if args.https else "http" + "://" + args.host + ":" + str(args.port) + args.path
             args.url = url
-            print "Deprecated arguments transformed into: '--url %s'" % url
+            print("Deprecated arguments transformed into: '--url %s'" % url)
 
     def __call__(self):
         """
@@ -355,11 +358,11 @@ class TaxiiScript(object):
                                         args.username,
                                         args.password)
 
-            print "Request:\n"
+            print("Request:\n")
             if args.xml_output is False:
-                print request_message.to_text()
+                print(request_message.to_text())
             else:
-                print request_message.to_xml(pretty_print=True)
+                print(request_message.to_xml(pretty_print=True))
 
             resp = client.call_taxii_service2(url.hostname,
                                               url.path,

--- a/libtaxii/scripts/__init__.py
+++ b/libtaxii/scripts/__init__.py
@@ -9,7 +9,7 @@ import sys
 import traceback
 import datetime
 import libtaxii.clients as tc
-from urllib.parse import urlparse
+from six.moves.urllib.parse import urlparse
 
 import libtaxii as t
 from libtaxii.common import gen_filename

--- a/libtaxii/scripts/__init__.py
+++ b/libtaxii/scripts/__init__.py
@@ -1,5 +1,5 @@
-from __future__ import absolute_import
-from __future__ import print_function
+
+
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file
 
@@ -9,7 +9,7 @@ import sys
 import traceback
 import datetime
 import libtaxii.clients as tc
-from urlparse import urlparse
+from urllib.parse import urlparse
 
 import libtaxii as t
 from libtaxii.common import gen_filename
@@ -208,7 +208,7 @@ class TaxiiScript(object):
         elif file_exists and write_type_ == W_PROMPT:
             var = None
             while var not in ('y', 'n'):
-                var = input("Overwrite file (%s)? (y/n): " % filename)
+                var = eval(input("Overwrite file (%s)? (y/n): " % filename))
             if var == 'y':
                 write = True
                 message = MSG_FILE_OVERWRITTEN

--- a/libtaxii/scripts/collection_information_client.py
+++ b/libtaxii/scripts/collection_information_client.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file
 """
-from __future__ import absolute_import
+
 
 import libtaxii.messages_11 as tm11
 from libtaxii.scripts import TaxiiScript

--- a/libtaxii/scripts/collection_information_client.py
+++ b/libtaxii/scripts/collection_information_client.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file
 """
+from __future__ import absolute_import
 
 import libtaxii.messages_11 as tm11
 from libtaxii.scripts import TaxiiScript

--- a/libtaxii/scripts/discovery_client.py
+++ b/libtaxii/scripts/discovery_client.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 #!/usr/bin/env python
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file

--- a/libtaxii/scripts/discovery_client.py
+++ b/libtaxii/scripts/discovery_client.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 #!/usr/bin/env python
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file

--- a/libtaxii/scripts/discovery_client_10.py
+++ b/libtaxii/scripts/discovery_client_10.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 #!/usr/bin/env python
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file

--- a/libtaxii/scripts/discovery_client_10.py
+++ b/libtaxii/scripts/discovery_client_10.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 #!/usr/bin/env python
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file

--- a/libtaxii/scripts/feed_information_client_10.py
+++ b/libtaxii/scripts/feed_information_client_10.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file
 """
-from __future__ import absolute_import
+
 
 import libtaxii.messages_10 as tm10
 from libtaxii.scripts import TaxiiScript

--- a/libtaxii/scripts/feed_information_client_10.py
+++ b/libtaxii/scripts/feed_information_client_10.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file
 """
+from __future__ import absolute_import
 
 import libtaxii.messages_10 as tm10
 from libtaxii.scripts import TaxiiScript

--- a/libtaxii/scripts/fulfillment_client.py
+++ b/libtaxii/scripts/fulfillment_client.py
@@ -1,5 +1,5 @@
-from __future__ import absolute_import
-from __future__ import print_function
+
+
 #!/usr/bin/env python
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file

--- a/libtaxii/scripts/fulfillment_client.py
+++ b/libtaxii/scripts/fulfillment_client.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 #!/usr/bin/env python
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file
@@ -40,9 +42,9 @@ class FulfillmentClient11Script(TaxiiScript):
     def handle_response(self, response, args):
         super(FulfillmentClient11Script, self).handle_response(response, args)
         if response.message_type == MSG_POLL_RESPONSE and response.more:
-            print "This response has More=True, to request additional parts, use the following command:"
-            print "  fulfillment_client --collection %s --result-id %s --result-part-number %s\r\n" % \
-                (response.collection_name, response.result_id, response.result_part_number + 1)
+            print("This response has More=True, to request additional parts, use the following command:")
+            print("  fulfillment_client --collection %s --result-id %s --result-part-number %s\r\n" % \
+                (response.collection_name, response.result_id, response.result_part_number + 1))
             self.write_cbs_from_poll_response_11(response, dest_dir=args.dest_dir, write_type_=args.write_type)
 
 

--- a/libtaxii/scripts/inbox_client.py
+++ b/libtaxii/scripts/inbox_client.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 #!/usr/bin/env python
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file

--- a/libtaxii/scripts/inbox_client.py
+++ b/libtaxii/scripts/inbox_client.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 #!/usr/bin/env python
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file

--- a/libtaxii/scripts/inbox_client_10.py
+++ b/libtaxii/scripts/inbox_client_10.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 #!/usr/bin/env python
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file

--- a/libtaxii/scripts/inbox_client_10.py
+++ b/libtaxii/scripts/inbox_client_10.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 #!/usr/bin/env python
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file

--- a/libtaxii/scripts/poll_client.py
+++ b/libtaxii/scripts/poll_client.py
@@ -1,5 +1,5 @@
-from __future__ import absolute_import
-from __future__ import print_function
+
+
 #!/usr/bin/env python
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file

--- a/libtaxii/scripts/poll_client.py
+++ b/libtaxii/scripts/poll_client.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 #!/usr/bin/env python
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file
@@ -57,9 +59,9 @@ class PollClient11Script(TaxiiScript):
             else:
                 end_ts = None
         except ValueError:
-            print "Unable to parse timestamp value. Timestamp should include both date and time " \
+            print("Unable to parse timestamp value. Timestamp should include both date and time " \
                   "information along with a timezone or UTC offset (e.g., YYYY-MM-DDTHH:MM:SS.ssssss+/-hh:mm). " \
-                  "Aborting poll."
+                  "Aborting poll.")
             sys.exit()
 
         create_kwargs = {'message_id': tm11.generate_message_id(),
@@ -79,9 +81,9 @@ class PollClient11Script(TaxiiScript):
 
         if response.message_type == MSG_POLL_RESPONSE:
             if response.more:
-                print "This response has More=True, to request additional parts, use the following command:"
-                print "  fulfillment_client --collection %s --result-id %s --result-part-number %s\r\n" % \
-                    (response.collection_name, response.result_id, response.result_part_number + 1)
+                print("This response has More=True, to request additional parts, use the following command:")
+                print("  fulfillment_client --collection %s --result-id %s --result-part-number %s\r\n" % \
+                    (response.collection_name, response.result_id, response.result_part_number + 1))
 
             self.write_cbs_from_poll_response_11(response, dest_dir=args.dest_dir, write_type_=args.write_type)
 

--- a/libtaxii/scripts/poll_client_10.py
+++ b/libtaxii/scripts/poll_client_10.py
@@ -1,5 +1,5 @@
-from __future__ import absolute_import
-from __future__ import print_function
+
+
 #!/usr/bin/env python
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file

--- a/libtaxii/scripts/poll_client_10.py
+++ b/libtaxii/scripts/poll_client_10.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 #!/usr/bin/env python
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file
@@ -57,8 +59,8 @@ class PollClient10Script(TaxiiScript):
             else:
                 end_ts = None
         except ValueError:
-            print "Unable to parse timestamp value. Timestamp should include both date and time information along " \
-                  "with a timezone or UTC offset (e.g., YYYY-MM-DDTHH:MM:SS.ssssss+/-hh:mm). Aborting poll."
+            print("Unable to parse timestamp value. Timestamp should include both date and time information along " \
+                  "with a timezone or UTC offset (e.g., YYYY-MM-DDTHH:MM:SS.ssssss+/-hh:mm). Aborting poll.")
             sys.exit()
 
         poll_req = tm10.PollRequest(message_id=tm10.generate_message_id(),

--- a/libtaxii/scripts/query_client.py
+++ b/libtaxii/scripts/query_client.py
@@ -1,10 +1,11 @@
+from __future__ import absolute_import
 #!/usr/bin/env python
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file
 
 import libtaxii.taxii_default_query as tdq
 from libtaxii.constants import *
-from poll_client import PollClient11Script
+from .poll_client import PollClient11Script
 
 
 class QueryClient11Script(PollClient11Script):

--- a/libtaxii/scripts/query_client.py
+++ b/libtaxii/scripts/query_client.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 #!/usr/bin/env python
 # Copyright (c) 2014, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file

--- a/libtaxii/taxii_default_query.py
+++ b/libtaxii/taxii_default_query.py
@@ -7,6 +7,7 @@
 """
 Creating, handling, and parsing TAXII Default Queries.
 """
+from __future__ import absolute_import
 
 import numbers
 import datetime
@@ -21,6 +22,7 @@ import libtaxii.messages_11 as tm11
 from .common import TAXIIBase
 from .validation import (do_check, uri_regex, targeting_expression_regex)
 from .constants import *
+import six
 
 
 class CapabilityModule(object):
@@ -40,7 +42,7 @@ class CapabilityModule(object):
 
     @capability_module_id.setter
     def capability_module_id(self, value):
-        do_check(value, 'capability_module_id', type=basestring)
+        do_check(value, 'capability_module_id', type=six.string_types)
         self._capability_module_id = value
 
     @property
@@ -67,7 +69,7 @@ class Relationship(object):
 
     @name.setter
     def name(self, value):
-        do_check(value, 'name', type=basestring)
+        do_check(value, 'name', type=six.string_types)
         self._name = value
 
     @property
@@ -94,10 +96,10 @@ class Parameter(object):
         return True, 'OK'
 
 # params - Define parameters for the Core/Regex/Timestamp capability modules
-param_str_value = Parameter(P_VALUE, basestring)
+param_str_value = Parameter(P_VALUE, six.string_types)
 param_float_value = Parameter(P_VALUE, float)
 param_ts_value = Parameter(P_VALUE, datetime.datetime)
-param_match_type = Parameter(P_MATCH_TYPE, basestring, ('case_sensitive_string', 'case_insensitive_string', 'number'))
+param_match_type = Parameter(P_MATCH_TYPE, six.string_types, ('case_sensitive_string', 'case_insensitive_string', 'number'))
 param_case_sensitive = Parameter(P_CASE_SENSITIVE, bool, (True, False))
 
 # CORE Relationships - Define relationships for the core capability module
@@ -265,7 +267,7 @@ class TargetingExpressionInfo(TAXIIBase):
 
     @preferred_scope.setter
     def preferred_scope(self, value):
-        do_check(value, 'preferred_scope', type=basestring, regex_tuple=targeting_expression_regex)
+        do_check(value, 'preferred_scope', type=six.string_types, regex_tuple=targeting_expression_regex)
         self._preferred_scope = value
 
     @property
@@ -274,7 +276,7 @@ class TargetingExpressionInfo(TAXIIBase):
 
     @allowed_scope.setter
     def allowed_scope(self, value):
-        do_check(value, 'allowed_scope', type=basestring, regex_tuple=targeting_expression_regex)
+        do_check(value, 'allowed_scope', type=six.string_types, regex_tuple=targeting_expression_regex)
         self._allowed_scope = value
 
     def to_etree(self):
@@ -554,7 +556,7 @@ class Criterion(TAXIIBase):
 
     @target.setter
     def target(self, value):
-        do_check(value, 'target', type=basestring)
+        do_check(value, 'target', type=six.string_types)
         self._target = value
 
     @property
@@ -650,7 +652,7 @@ class Test(TAXIIBase):
     def relationship(self, value):
         # TODO: For known capability IDs, check that the relationship is valid
         # TODO: provide a way to register other capability IDs
-        do_check(value, 'relationship', type=basestring)
+        do_check(value, 'relationship', type=six.string_types)
         self._relationship = value
 
     @property
@@ -659,7 +661,7 @@ class Test(TAXIIBase):
 
     @parameters.setter
     def parameters(self, value):
-        do_check(value.keys(), 'parameters.keys()', regex_tuple=uri_regex)
+        do_check(list(value.keys()), 'parameters.keys()', regex_tuple=uri_regex)
         self._parameters = value
 
     # TODO: Can this be done better?
@@ -670,12 +672,12 @@ class Test(TAXIIBase):
 
         relationship = capability_module.relationships.get(self.relationship)
         if relationship is None:
-            raise Exception('relationship not in defined relationships. %s not in %s' % (self.relationship, capability_module.relationships.keys()))
+            raise Exception('relationship not in defined relationships. %s not in %s' % (self.relationship, list(capability_module.relationships.keys())))
 
-        for name, value in self.parameters.items():
+        for name, value in list(self.parameters.items()):
             param = relationship.parameters.get(name)
             if param is None:
-                raise Exception('name not valid. %s not in %s' % (name, relationship.parameters.keys()))
+                raise Exception('name not valid. %s not in %s' % (name, list(relationship.parameters.keys())))
             param.verify(value)
 
     def to_etree(self):
@@ -683,7 +685,7 @@ class Test(TAXIIBase):
         t.attrib['capability_id'] = self.capability_id
         t.attrib['relationship'] = self.relationship
 
-        for k, v in self.parameters.items():
+        for k, v in list(self.parameters.items()):
             p = etree.SubElement(t, '{%s}Parameter' % ns_map['tdq'])
             p.attrib['name'] = k
             if isinstance(v, bool):
@@ -708,7 +710,7 @@ class Test(TAXIIBase):
         s = line_prepend + "=== Test ==\n"
         s += line_prepend + "  Capability ID: %s\n" % self.capability_id
         s += line_prepend + "  Relationship: %s\n" % self.relationship
-        for k, v in self.parameters.iteritems():
+        for k, v in six.iteritems(self.parameters):
             s += line_prepend + "  Parameter: %s = %s\n" % (k, v)
 
         return s
@@ -735,7 +737,7 @@ class Test(TAXIIBase):
                 parameters[k] = v == 'true'
             elif r is not None:
                 type_ = r.parameters[k].type
-                if type_ == basestring:  # basestring can't be instantiated, but str can be
+                if type_ == six.string_types:  # basestring can't be instantiated, but str can be
                     type_ = str
                 elif type_ == datetime.datetime:
                     # We can use this function to parse datetime strings.

--- a/libtaxii/taxii_default_query.py
+++ b/libtaxii/taxii_default_query.py
@@ -7,7 +7,7 @@
 """
 Creating, handling, and parsing TAXII Default Queries.
 """
-from __future__ import absolute_import
+
 
 import numbers
 import datetime

--- a/libtaxii/test/clients_test.py
+++ b/libtaxii/test/clients_test.py
@@ -1,5 +1,5 @@
-from __future__ import absolute_import
-from __future__ import print_function
+
+
 # Copyright (C) 2013 - The MITRE Corporation
 # For license information, see the LICENSE.txt file
 

--- a/libtaxii/test/clients_test.py
+++ b/libtaxii/test/clients_test.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 # Copyright (C) 2013 - The MITRE Corporation
 # For license information, see the LICENSE.txt file
 
@@ -41,11 +43,11 @@ def client_example():
     # Call without a proxy
     http_response = client.call_taxii_service2('hostname', '/poll_service_path/', VID_TAXII_XML_10, poll_request1.to_xml())
 
-    print http_response.__class__.__name__
+    print(http_response.__class__.__name__)
 
     taxii_message = t.get_message_from_http_response(http_response,
                                                      poll_request1.message_id)
-    print(taxii_message.to_xml())
+    print((taxii_message.to_xml()))
 
 if __name__ == "__main__":
     client_example()

--- a/libtaxii/test/messages_10_test.py
+++ b/libtaxii/test/messages_10_test.py
@@ -1,5 +1,5 @@
-from __future__ import absolute_import
-from __future__ import print_function
+
+
 # Copyright (C) 2013 - The MITRE Corporation
 # For license information, see the LICENSE.txt file
 
@@ -11,7 +11,7 @@ from __future__ import print_function
 # * Mark Davidson - mdavidson@mitre.org
 
 import datetime
-import StringIO
+import io
 import unittest
 import warnings
 import inspect
@@ -64,11 +64,11 @@ full_stix_doc = """<stix:STIX_Package
     </stix:Indicators>
 </stix:STIX_Package>"""
 
-full_stix_etree = etree.parse(StringIO.StringIO(full_stix_doc)).getroot()
+full_stix_etree = etree.parse(io.StringIO(full_stix_doc)).getroot()
 
 # TODO: This is bad practice. Refactor this.
 # Set up some things used across multiple tests.
-stix_etree = etree.parse(StringIO.StringIO('<stix:STIX_Package xmlns:stix="http://stix.mitre.org/stix-1"/>')).getroot()
+stix_etree = etree.parse(io.StringIO('<stix:STIX_Package xmlns:stix="http://stix.mitre.org/stix-1"/>')).getroot()
 
 xml_content_block1 = tm10.ContentBlock(
     content_binding=CB_STIX_XML_10,  # Required
@@ -383,7 +383,7 @@ class StatusMessageTests(unittest.TestCase):
         :return:
         """
 
-        eh = {'my_ext_header_1': etree.parse(StringIO.StringIO('<x:element xmlns:x="#foo">'
+        eh = {'my_ext_header_1': etree.parse(io.StringIO('<x:element xmlns:x="#foo">'
                                                                '<x:subelement attribute="something"/>'
                                                                '</x:element>'))}
 
@@ -549,12 +549,12 @@ class ContentBlockTests(unittest.TestCase):
 
     def test_content_block2(self):
         cb2 = tm10.ContentBlock(content_binding=CB_STIX_XML_10,
-                                content=StringIO.StringIO('<stix:STIX_Package xmlns:stix="http://stix.mitre.org/stix-1"/>'))
+                                content=io.StringIO('<stix:STIX_Package xmlns:stix="http://stix.mitre.org/stix-1"/>'))
         round_trip_content_block(cb2)
 
     def test_content_block3(self):
         cb3 = tm10.ContentBlock(content_binding=CB_STIX_XML_10,
-                                content=etree.parse(StringIO.StringIO('<stix:STIX_Package xmlns:stix="http://stix.mitre.org/stix-1"/>')))
+                                content=etree.parse(io.StringIO('<stix:STIX_Package xmlns:stix="http://stix.mitre.org/stix-1"/>')))
         round_trip_content_block(cb3)
 
     def test_content_block4(self):

--- a/libtaxii/test/messages_10_test.py
+++ b/libtaxii/test/messages_10_test.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 # Copyright (C) 2013 - The MITRE Corporation
 # For license information, see the LICENSE.txt file
 
@@ -21,6 +23,7 @@ import libtaxii as t
 import libtaxii.messages_10 as tm10
 from libtaxii.validation import SchemaValidator
 from libtaxii.constants import *
+import six
 
 
 full_stix_doc = """<stix:STIX_Package
@@ -90,7 +93,7 @@ def round_trip_message(taxii_message):
     if not isinstance(taxii_message, tm10.TAXIIMessage):
         raise ValueError('taxii_message was not an instance of TAXIIMessage')
 
-    print '***** Message type = %s; id = %s' % (taxii_message.message_type, taxii_message.message_id)
+    print('***** Message type = %s; id = %s' % (taxii_message.message_type, taxii_message.message_id))
 
     xml_string = taxii_message.to_xml()
     # This is the old, deprecated way of validating
@@ -116,28 +119,28 @@ def round_trip_message(taxii_message):
     msg_from_dict = tm10.get_message_from_dict(dictionary)
     taxii_message.to_text()
     if taxii_message != msg_from_xml:
-        print '\t Failure of test #2 - running equals w/ debug:'
+        print('\t Failure of test #2 - running equals w/ debug:')
         taxii_message.__eq__(msg_from_xml, True)
         raise Exception('Test #2 failed - taxii_message != msg_from_xml')
 
     if taxii_message != msg_from_dict:
-        print '\t Failure of test #3 - running equals w/ debug:'
+        print('\t Failure of test #3 - running equals w/ debug:')
         taxii_message.__eq__(msg_from_dict, True)
         raise Exception('Test #3 failed - taxii_message != msg_from_dict')
 
     if msg_from_xml != msg_from_dict:
-        print '\t Failure of test #4 - running equals w/ debug:'
+        print('\t Failure of test #4 - running equals w/ debug:')
         msg_from_xml.__eq__(msg_from_dict, True)
         raise Exception('Test #4 failed - msg_from_xml != msg_from_dict')
 
-    print '***** All tests completed!'
+    print('***** All tests completed!')
 
 
 def round_trip_content_block(content_block):
     if not isinstance(content_block, tm10.ContentBlock):
         raise ValueError('content_block was not an instance of ContentBlock')
 
-    print '***** Starting Content Block tests'
+    print('***** Starting Content Block tests')
 
     xml_string = content_block.to_xml()
     block_from_xml = tm10.ContentBlock.from_xml(xml_string)
@@ -148,25 +151,25 @@ def round_trip_content_block(content_block):
     content_block.to_text()
 
     if content_block != block_from_xml:
-        print '\t Failure of test #1 - running equals w/ debug:'
+        print('\t Failure of test #1 - running equals w/ debug:')
         content_block.__equals(block_from_xml, True)
         raise Exception('Test #1 failed - content_block != block_from_xml')
 
     if content_block != block_from_dict:
-        print '\t Failure of test #2 - running equals w/ debug:'
+        print('\t Failure of test #2 - running equals w/ debug:')
         content_block.__eq__(block_from_dict, True)
         raise Exception('Test #2 failed - content_block != block_from_dict')
 
     if block_from_xml != block_from_dict:
-        print '\t Failure of test #3 - running equals w/ debug:'
+        print('\t Failure of test #3 - running equals w/ debug:')
         block_from_xml.__eq__(block_from_dict, True)
         raise Exception('Test #3 failed - block_from_xml != block_from_dict')
     if block_from_json != block_from_dict:
-        print '\t Failure of test #3 - running equals w/ debug:'
+        print('\t Failure of test #3 - running equals w/ debug:')
         block_from_json.__eq__(block_from_dict, True)
         raise Exception('Test #3 failed - block_from_json != block_from_dict')
 
-    print '***** All tests completed!'
+    print('***** All tests completed!')
 
 
 class DiscoveryRequestTests(unittest.TestCase):
@@ -565,7 +568,7 @@ class ContentBlockTests(unittest.TestCase):
         round_trip_content_block(cb5)
 
     def test_content_block6(self):
-        cb6 = tm10.ContentBlock(content_binding='RandomUnicodeString', content=unicode('abcdef'))
+        cb6 = tm10.ContentBlock(content_binding='RandomUnicodeString', content=six.text_type('abcdef'))
         round_trip_content_block(cb6)
 
 

--- a/libtaxii/test/messages_10_test.py
+++ b/libtaxii/test/messages_10_test.py
@@ -11,7 +11,6 @@
 # * Mark Davidson - mdavidson@mitre.org
 
 import datetime
-import io
 import unittest
 import warnings
 import inspect
@@ -64,11 +63,11 @@ full_stix_doc = """<stix:STIX_Package
     </stix:Indicators>
 </stix:STIX_Package>"""
 
-full_stix_etree = etree.parse(io.StringIO(full_stix_doc)).getroot()
+full_stix_etree = etree.parse(six.StringIO(full_stix_doc)).getroot()
 
 # TODO: This is bad practice. Refactor this.
 # Set up some things used across multiple tests.
-stix_etree = etree.parse(io.StringIO('<stix:STIX_Package xmlns:stix="http://stix.mitre.org/stix-1"/>')).getroot()
+stix_etree = etree.parse(six.StringIO('<stix:STIX_Package xmlns:stix="http://stix.mitre.org/stix-1"/>')).getroot()
 
 xml_content_block1 = tm10.ContentBlock(
     content_binding=CB_STIX_XML_10,  # Required
@@ -383,7 +382,7 @@ class StatusMessageTests(unittest.TestCase):
         :return:
         """
 
-        eh = {'my_ext_header_1': etree.parse(io.StringIO('<x:element xmlns:x="#foo">'
+        eh = {'my_ext_header_1': etree.parse(six.StringIO('<x:element xmlns:x="#foo">'
                                                                '<x:subelement attribute="something"/>'
                                                                '</x:element>'))}
 
@@ -549,12 +548,12 @@ class ContentBlockTests(unittest.TestCase):
 
     def test_content_block2(self):
         cb2 = tm10.ContentBlock(content_binding=CB_STIX_XML_10,
-                                content=io.StringIO('<stix:STIX_Package xmlns:stix="http://stix.mitre.org/stix-1"/>'))
+                                content=six.StringIO('<stix:STIX_Package xmlns:stix="http://stix.mitre.org/stix-1"/>'))
         round_trip_content_block(cb2)
 
     def test_content_block3(self):
         cb3 = tm10.ContentBlock(content_binding=CB_STIX_XML_10,
-                                content=etree.parse(io.StringIO('<stix:STIX_Package xmlns:stix="http://stix.mitre.org/stix-1"/>')))
+                                content=etree.parse(six.StringIO('<stix:STIX_Package xmlns:stix="http://stix.mitre.org/stix-1"/>')))
         round_trip_content_block(cb3)
 
     def test_content_block4(self):

--- a/libtaxii/test/messages_11_test.py
+++ b/libtaxii/test/messages_11_test.py
@@ -1,5 +1,5 @@
-from __future__ import absolute_import
-from __future__ import print_function
+
+
 # Copyright (C) 2013 - The MITRE Corporation
 # For license information, see the LICENSE.txt file
 
@@ -11,7 +11,7 @@ from __future__ import print_function
 # * Mark Davidson - mdavidson@mitre.org
 
 import datetime
-import StringIO
+import io
 import sys
 import unittest
 import warnings

--- a/libtaxii/test/messages_11_test.py
+++ b/libtaxii/test/messages_11_test.py
@@ -1121,7 +1121,7 @@ class ContentBlockTests(unittest.TestCase):
 
     def test_content_block02(self):
         cb2 = tm11.ContentBlock(content_binding=tm11.ContentBinding(CB_STIX_XML_10),
-                                content=StringIO('<stix:STIX_Package xmlns:stix="http://stix.mitre.org/stix-1"/>'))
+                                content=six.StringIO('<stix:STIX_Package xmlns:stix="http://stix.mitre.org/stix-1"/>'))
         round_trip_content_block(cb2)
 
     def test_content_block03(self):

--- a/libtaxii/test/messages_11_test.py
+++ b/libtaxii/test/messages_11_test.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 # Copyright (C) 2013 - The MITRE Corporation
 # For license information, see the LICENSE.txt file
 
@@ -24,6 +26,7 @@ import libtaxii.taxii_default_query as tdq
 from libtaxii.validation import SchemaValidator
 from libtaxii.constants import *
 from libtaxii.common import *
+import six
 
 # TODO: This is bad practice. Refactor this.
 # Set up some things used across multiple tests.
@@ -151,11 +154,11 @@ def round_trip_message(taxii_message, print_xml=False):
         warnings.simplefilter('ignore', DeprecationWarning)
         valid = tm11.validate_xml(xml_string)
     if valid is not True:
-        print 'Bad XML was:'
+        print('Bad XML was:')
         try:
-            print etree.tostring(taxii_message.to_etree(), pretty_print=True)
+            print(etree.tostring(taxii_message.to_etree(), pretty_print=True))
         except Exception as e:
-            print xml_string
+            print(xml_string)
         raise Exception('\tFailure of test #1 - XML not schema valid: %s' % valid)
 
     # The new way of validating
@@ -170,24 +173,24 @@ def round_trip_message(taxii_message, print_xml=False):
         raise Exception('\tFailure of test #1 - XML not schema valid: %s' % errors)
 
     if print_xml:
-        print etree.tostring(taxii_message.to_etree(), pretty_print=True)
+        print(etree.tostring(taxii_message.to_etree(), pretty_print=True))
 
     msg_from_xml = tm11.get_message_from_xml(xml_string)
     dictionary = taxii_message.to_dict()
     msg_from_dict = tm11.get_message_from_dict(dictionary)
     taxii_message.to_text()  # to_text() returns a string, this just makes sure the call succeeds but doesn't validate the response
     if taxii_message != msg_from_xml:
-        print '\t Failure of test #2 - running equals w/ debug:'
+        print('\t Failure of test #2 - running equals w/ debug:')
         taxii_message.__eq__(msg_from_xml, True)
         raise Exception('Test #2 failed - taxii_message != msg_from_xml')
 
     if taxii_message != msg_from_dict:
-        print '\t Failure of test #3 - running equals w/ debug:'
+        print('\t Failure of test #3 - running equals w/ debug:')
         taxii_message.__eq__(msg_from_dict, True)
         raise Exception('Test #3 failed - taxii_message != msg_from_dict')
 
     if msg_from_xml != msg_from_dict:
-        print '\t Failure of test #4 - running equals w/ debug:'
+        print('\t Failure of test #4 - running equals w/ debug:')
         msg_from_xml.__eq__(msg_from_dict, True)
         raise Exception('Test #4 failed - msg_from_xml != msg_from_dict')
 
@@ -209,21 +212,21 @@ def round_trip_content_block(content_block):
     content_block.to_text()
 
     if content_block != block_from_xml:
-        print '\t Failure of test #1 - running equals w/ debug:'
+        print('\t Failure of test #1 - running equals w/ debug:')
         content_block.__eq__(block_from_xml, True)
         raise Exception('Test #1 failed - content_block != block_from_xml')
 
     if content_block != block_from_dict:
-        print '\t Failure of test #2 - running equals w/ debug:'
+        print('\t Failure of test #2 - running equals w/ debug:')
         content_block.__eq__(block_from_dict, True)
         raise Exception('Test #2 failed - content_block != block_from_dict')
 
     if block_from_xml != block_from_dict:
-        print '\t Failure of test #3 - running equals w/ debug:'
+        print('\t Failure of test #3 - running equals w/ debug:')
         block_from_xml.__eq__(block_from_dict, True)
         raise Exception('Test #3 failed - block_from_xml != block_from_dict')
     if block_from_json != block_from_dict:
-        print '\t Failure of test #3 - running equals w/ debug:'
+        print('\t Failure of test #3 - running equals w/ debug:')
         block_from_json.__eq__(block_from_dict, True)
         raise Exception('Test #3 failed - block_from_json != block_from_dict')
 
@@ -1137,7 +1140,7 @@ class ContentBlockTests(unittest.TestCase):
         round_trip_content_block(cb5)
 
     def test_content_block06(self):
-        cb6 = tm11.ContentBlock(content_binding='RandomUnicodeString', content=unicode('abcdef'))
+        cb6 = tm11.ContentBlock(content_binding='RandomUnicodeString', content=six.text_type('abcdef'))
         round_trip_content_block(cb6)
 
     def test_content_block07(self):

--- a/libtaxii/test/to_text_11_test.py
+++ b/libtaxii/test/to_text_11_test.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 #!/usr/bin/env python
 # Copyright (c) 2015, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file

--- a/libtaxii/test/to_text_11_test.py
+++ b/libtaxii/test/to_text_11_test.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 #!/usr/bin/env python
 # Copyright (c) 2015, The MITRE Corporation. All rights reserved.
 # For license information, see the LICENSE.txt file

--- a/libtaxii/test/validation_test.py
+++ b/libtaxii/test/validation_test.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 # Copyright (C) 2105 - The MITRE Corporation
 # For license information, see the LICENSE.txt file
 

--- a/libtaxii/test/validation_test.py
+++ b/libtaxii/test/validation_test.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Copyright (C) 2105 - The MITRE Corporation
 # For license information, see the LICENSE.txt file
 

--- a/libtaxii/validation.py
+++ b/libtaxii/validation.py
@@ -7,7 +7,7 @@
 """
 Common data validation functions used across libtaxii
 """
-from __future__ import absolute_import
+
 
 import collections
 import re

--- a/libtaxii/validation.py
+++ b/libtaxii/validation.py
@@ -7,6 +7,7 @@
 """
 Common data validation functions used across libtaxii
 """
+from __future__ import absolute_import
 
 import collections
 import re
@@ -15,6 +16,7 @@ from lxml import etree
 import os
 
 from .common import (parse, parse_datetime_string)
+import six
 
 # General purpose helper methods #
 
@@ -67,7 +69,7 @@ def do_check(var, varname, type=None, regex_tuple=None, value_tuple=None, can_be
             raise ValueError(_type_error % (varname, type, bad_type))
 
     if regex_tuple is not None:
-        if not isinstance(var, basestring):
+        if not isinstance(var, six.string_types):
             raise ValueError('%s was about to undergo a regex check, but is not of type basestring! Regex check was not performed' % (varname))
         if re.match(regex_tuple.regex, var) is None:
             raise ValueError(_regex_error % (varname, regex_tuple.title, var))
@@ -96,7 +98,7 @@ def check_timestamp_label(timestamp_label, varname, can_be_none=False):
     if timestamp_label is None and not can_be_none:
         raise ValueError(_none_error % varname)
 
-    if isinstance(timestamp_label, basestring):
+    if isinstance(timestamp_label, six.string_types):
         timestamp_label = parse_datetime_string(timestamp_label)
 
     do_check(timestamp_label, varname, type=datetime.datetime, can_be_none=can_be_none)

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ from setuptools import setup, find_packages
 BASE_DIR = dirname(abspath(__file__))
 VERSION_FILE = join(BASE_DIR, 'libtaxii', 'version.py')
 
+
 def get_version():
     with open(VERSION_FILE) as f:
         for line in f.readlines():
@@ -23,7 +24,12 @@ def get_version():
 if sys.version_info < (2, 6):
     raise Exception('libtaxii requires Python 2.6 or higher.')
 
-install_requires = ['lxml>=2.2.3', 'python-dateutil>=1.4.1']
+install_requires = [
+    'lxml>=2.2.3',
+    'python-dateutil>=1.4.1',
+    'six>=1.9.0',
+]
+
 try:
     import argparse
 except ImportError:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, rhel6
+envlist = py26, py27, rhel6, py34
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -15,4 +15,5 @@ commands =
 deps =
     lxml==2.2.3
     python-dateutil==1.4.1
+    six==1.9.0
     nose


### PR DESCRIPTION
* Fix `urllib` and `httplib` imports using the `six` module, which is already present through the `lxml` dependency.
* Fix the use of `StringIO` depending on if the strings are binary or unicode.
* Refactored a `parse_xml_string` helper function to prevent code duplication.
* Altered `to_json` because binary values cannot be dumped to json.
* Refactored `to_json` into the `common` module to prevent code duplication.