### PR TITLE
Fix typo in common.get_xml_parser docstring

### DIFF
--- a/libtaxii/common.py
+++ b/libtaxii/common.py
@@ -60,7 +60,7 @@ def get_xml_parser():
 
     If one has not already been set (via :py:func:`set_xml_parser()`), a new
     ``etree.XMLParser`` is constructed with ``no_network=True`` and
-    ``huge_tree=True``.
+    ``huge_tree=False``.
     """
     global _XML_PARSER
     if _XML_PARSER is None:


### PR DESCRIPTION
As noted by @MarkDavidson in comments on #183, it is the comment that is wrong, not the code.