### PR TITLE
Fix parsing of `status_detail` values

### DIFF
--- a/libtaxii/messages_11.py
+++ b/libtaxii/messages_11.py
@@ -3012,7 +3012,7 @@ class StatusMessage(TAXIIMessage):
                 if name not in kwargs['status_detail']:
                     kwargs['status_detail'][name] = v
                 else:  # It already exists
-                    if not isinstance(kwargs['status_detail'], list):
+                    if not isinstance(kwargs['status_detail'][name], list):
                         kwargs['status_detail'][name] = [kwargs['status_detail'][name]]  # Make it a list
                     kwargs['status_detail'][name].append(v)
             else:


### PR DESCRIPTION
The `isinstance` check was checking the base `status_detail` key, rather than the key we were iterating over.  This means that we were wrapping the existing value in a list on every iteration, rather than just the first time.

I've added a unit test which fails without the change and passes with it.