### PR TITLE
Command-line changes

### DIFF
--- a/libtaxii/test/argument_parser_test.py
+++ b/libtaxii/test/argument_parser_test.py
@@ -1,0 +1,24 @@
+import unittest
+
+import libtaxii.scripts.poll_client as pc11
+
+
+class ArgumentParserTests(unittest.TestCase):
+
+    def test_valid_argument_passing_poll_client11(self):
+        script = pc11.PollClient11Script()
+        arg_parse = script.get_arg_parser(script.parser_description, path=script.path)
+        namespace = arg_parse.parse_args(["--from-file", "data/configuration.ini"])
+        self.assertEqual(namespace.url, "http://hailataxii2.com:80")
+        self.assertEqual(namespace.path, "/taxii-data")
+        self.assertEqual(namespace.port, 80)
+        self.assertEqual(namespace.password, "myS3crEtp@asswOrd!")
+
+    def test_argument_override_poll_client11(self):
+        script = pc11.PollClient11Script()
+        arg_parse = script.get_arg_parser(script.parser_description, path=script.path)
+        namespace = arg_parse.parse_args(["-u", "http://hailataxii.com:80", "--from-file", "data/configuration.ini"])
+        self.assertEqual(namespace.url, "http://hailataxii2.com:80")  # note the argument was overwritten
+        self.assertEqual(namespace.path, "/taxii-data")
+        self.assertEqual(namespace.port, 80)
+        self.assertEqual(namespace.password, "myS3crEtp@asswOrd!")

--- a/libtaxii/test/argument_parser_test.py
+++ b/libtaxii/test/argument_parser_test.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 import libtaxii.scripts.poll_client as pc11
@@ -5,10 +6,17 @@ import libtaxii.scripts.poll_client as pc11
 
 class ArgumentParserTests(unittest.TestCase):
 
+    def setUp(self):
+        self.module_path = os.path.dirname(__file__)
+
     def test_valid_argument_passing_poll_client11(self):
         script = pc11.PollClient11Script()
         arg_parse = script.get_arg_parser(script.parser_description, path=script.path)
-        namespace = arg_parse.parse_args(["--from-file", "data/configuration.ini"])
+        namespace = arg_parse.parse_args(
+            [
+                "--from-file", os.path.join(self.module_path, "data", "configuration.ini")
+            ]
+        )
         self.assertEqual(namespace.url, "http://hailataxii2.com:80")
         self.assertEqual(namespace.path, "/taxii-data")
         self.assertEqual(namespace.port, 80)
@@ -17,7 +25,12 @@ class ArgumentParserTests(unittest.TestCase):
     def test_argument_override_poll_client11(self):
         script = pc11.PollClient11Script()
         arg_parse = script.get_arg_parser(script.parser_description, path=script.path)
-        namespace = arg_parse.parse_args(["-u", "http://hailataxii.com:80", "--from-file", "data/configuration.ini"])
+        namespace = arg_parse.parse_args(
+            [
+                "-u", "http://hailataxii.com:80",
+                "--from-file", os.path.join(self.module_path, "data", "configuration.ini")
+            ]
+        )
         self.assertEqual(namespace.url, "http://hailataxii2.com:80")  # note the argument was overwritten
         self.assertEqual(namespace.path, "/taxii-data")
         self.assertEqual(namespace.port, 80)

--- a/libtaxii/test/data/configuration.ini
+++ b/libtaxii/test/data/configuration.ini
@@ -1,0 +1,3 @@
+[libtaxii]
+url = http://hailataxii2.com:80
+pass = myS3crEtp@asswOrd!


### PR DESCRIPTION
Add ability to load an INI configuration file to all of the scripts. The configuration file **has** precedence over flags passed from the console. Thus, use with caution. Since many default values are used inside, it was easier to maintain backwards compatibility via this approach. The keys in the ini file must match the long version of the argument (e.g., --username, --pass, --xml-output, --subscription-id, etc).

Example:
``` ini
[libtaxii]
username = USERNAME
pass = PASSWORD
cert = <location of cert to use>
key = <location of key file to use>
```
How to use it:

``` bash
> poll_client --url https://some-site.com:80 --from-file <path to my config file>
```

closes #234 