### PR TITLE
Support converting dicts to content bindings

### DIFF
--- a/libtaxii/messages_11.py
+++ b/libtaxii/messages_11.py
@@ -169,6 +169,7 @@ def _sanitize_content_binding(binding):
     Takes in one of:
     1. ContentBinding object
     2. string
+    3. dict
     and returns a ContentBinding object.
 
     This supports function calls where a string or ContentBinding can be
@@ -178,6 +179,8 @@ def _sanitize_content_binding(binding):
         return binding
     elif isinstance(binding, six.string_types):  # Convert it to a ContentBinding
         return ContentBinding.from_string(binding)
+    elif isinstance(binding, dict):  # Convert it to a ContentBinding
+        return ContentBinding.from_dict(binding)
     else:  # Don't know what to do with it.
         raise ValueError('Type cannot be converted to ContentBinding: %s' % binding.__class__.__name__)
 

--- a/libtaxii/test/messages_11_test.py
+++ b/libtaxii/test/messages_11_test.py
@@ -759,7 +759,7 @@ class ManageCollectionSubscriptionRequestTests(unittest.TestCase):
         subs_req3 = tm11.ManageCollectionSubscriptionRequest(
             message_id='SubsReq03',  # Required
             action=ACT_SUBSCRIBE,  # Required
-            collection_name='collection213',  # Required
+            collection_name='collection2',  # Required
             # subscription_id = None, #Prohibited for action = SUBSCRIBE
             subscription_parameters=subscription_parameters3)  # optional - absence means there are not any subscription parameters
         # delivery_parameters = None)#Optional - absence means push messaging not requested
@@ -816,6 +816,21 @@ class ManageCollectionSubscriptionRequestTests(unittest.TestCase):
         # subscription_parameters, delivery_parameters prohibited if action != SUBSCRIBE
 
         round_trip_message(subs_req8)
+
+    def test_subs_req9(self):
+        # https://github.com/TAXIIProject/libtaxii/pull/237
+        subscription = """{"content_bindings": [{"binding_id": "urn:stix.mitre.org:xml:1.2"}], "query": null, "response_type": "FULL"}"""
+        subscription_dict = json.loads(subscription)
+        subscription_parameters3 = tm11.SubscriptionParameters(**subscription_dict)  # Use all the defaults
+        subs_req3 = tm11.ManageCollectionSubscriptionRequest(
+            message_id='SubsReq09',  # Required
+            action=ACT_SUBSCRIBE,  # Required
+            collection_name='collection2',  # Required
+            # subscription_id = None, #Prohibited for action = SUBSCRIBE
+            subscription_parameters=subscription_parameters3)  # optional - absence means there are not any subscription parameters
+        # delivery_parameters = None)#Optional - absence means push messaging not requested
+
+        round_trip_message(subs_req3)
 
 
 class ManageCollectionSubscriptionResponseTests(unittest.TestCase):


### PR DESCRIPTION
If `subscription_parameters` in the form of a dict are stored and later retrieved it's not possible to turn them into a `SubscriptionParameters` object by doing `tm11.SubscriptionParameters(**subscription.subscription_parameters)`. This is the case even though it's possible for `ContentBinding` objects to be loaded from dicts. This PR adds dict conversion to the `_sanitize_content_binding` method which currently only performs conversions on strings.

An example `subscripion_parameters` value is as follows:

```python
{"content_bindings": [{"binding_id": "urn:stix.mitre.org:xml:1.2"}], "query": null, "response_type": "FULL"}
```