### PR TITLE
PY3 compatibility for HTTP response body

### DIFF
--- a/libtaxii/__init__.py
+++ b/libtaxii/__init__.py
@@ -90,7 +90,7 @@ def get_message_from_urllib_addinfourl(http_response, in_response_to):
         _, params = cgi.parse_header(info.get('Content-Type'))
 
     encoding = params.get('charset', 'utf-8')
-    response_message = http_response.read()
+    response_message = six.ensure_text(http_response.read(), errors='replace')
 
     if taxii_content_type is None:  # Treat it as a Failure Status Message, per the spec
 
@@ -125,7 +125,7 @@ def get_message_from_httplib_http_response(http_response, in_response_to):
         _, params = cgi.parse_header(http_response.get('Content-Type'))
 
     encoding = params.get('charset', 'utf-8')
-    response_message = http_response.read()
+    response_message = six.ensure_text(http_response.read(, errors='replace'))
 
     if taxii_content_type is None:  # Treat it as a Failure Status Message, per the spec
 

--- a/libtaxii/__init__.py
+++ b/libtaxii/__init__.py
@@ -125,7 +125,7 @@ def get_message_from_httplib_http_response(http_response, in_response_to):
         _, params = cgi.parse_header(http_response.get('Content-Type'))
 
     encoding = params.get('charset', 'utf-8')
-    response_message = six.ensure_text(http_response.read(, errors='replace'))
+    response_message = six.ensure_text(http_response.read(), errors='replace'))
 
     if taxii_content_type is None:  # Treat it as a Failure Status Message, per the spec
 

--- a/libtaxii/__init__.py
+++ b/libtaxii/__init__.py
@@ -61,11 +61,9 @@ def get_message_from_urllib2_httperror(http_response, in_response_to):
         _, params = cgi.parse_header(info.get('Content-Type'))
 
     encoding = params.get('charset', 'utf-8')
-    response_message = http_response.read()
+    response_message = six.ensure_text(http_response.read(), errors='replace')
 
     if taxii_content_type is None:
-        if isinstance(response_message, six.binary_type):
-            response_message = response_message.decode(encoding, 'replace')
         m = str(http_response) + '\r\n' + str(http_response.info()) + '\r\n' + response_message
         return tm11.StatusMessage(message_id='0', in_response_to=in_response_to, status_type=ST_FAILURE, message=m)
     elif taxii_content_type == VID_TAXII_XML_10:  # It's a TAXII XML 1.0 message

--- a/libtaxii/__init__.py
+++ b/libtaxii/__init__.py
@@ -125,7 +125,7 @@ def get_message_from_httplib_http_response(http_response, in_response_to):
         _, params = cgi.parse_header(http_response.get('Content-Type'))
 
     encoding = params.get('charset', 'utf-8')
-    response_message = six.ensure_text(http_response.read(), errors='replace'))
+    response_message = six.ensure_text(http_response.read(), errors='replace')
 
     if taxii_content_type is None:  # Treat it as a Failure Status Message, per the spec
 


### PR DESCRIPTION
Add Python 3 compatibility to the handling of an HTTP response body. In Python 3, `http_response.read()` returns a byte string when libtaxii is expecting it to be a string. If `taxii_content_type is None`, this will raise the following exception:

``` 
File ".../venv/lib/python3.7/site-packages/libtaxii/__init__.py", line 139, in get_message_from_httplib_http_response
    m = ''.join(message)
TypeError: sequence item 10: expected str instance, bytes found```