### PR TITLE
Writing content blocks should not be dependent on value of "more"

### DIFF
--- a/libtaxii/scripts/fulfillment_client.py
+++ b/libtaxii/scripts/fulfillment_client.py
@@ -40,10 +40,11 @@ class FulfillmentClient11Script(TaxiiScript):
 
     def handle_response(self, response, args):
         super(FulfillmentClient11Script, self).handle_response(response, args)
-        if response.message_type == MSG_POLL_RESPONSE and response.more:
-            print("This response has More=True, to request additional parts, use the following command:")
-            print("  fulfillment_client --collection %s --result-id %s --result-part-number %s\r\n" % \
-                (response.collection_name, response.result_id, response.result_part_number + 1))
+        if response.message_type == MSG_POLL_RESPONSE:
+            if response.more:
+                print("This response has More=True, to request additional parts, use the following command:")
+                print("  fulfillment_client --collection %s --result-id %s --result-part-number %s\r\n" % \
+                    (response.collection_name, response.result_id, response.result_part_number + 1))
             self.write_cbs_from_poll_response_11(response, dest_dir=args.dest_dir, write_type_=args.write_type)
 
 


### PR DESCRIPTION
The fulfillment_client only writes content blocks to file if More=True, preventing the user from receiving the last result part when More=False. This change breaks out the call to `self.write_cbs_from_poll_response_11()` such that it will now occur any time `response.message_type == MSG_POLL_RESPONSE`, regardless of the value in `response.more`.