### PR TITLE
Properly Group API Docs

### DIFF
--- a/docs/api/clients.rst
+++ b/docs/api/clients.rst
@@ -1,5 +1,5 @@
-:mod:`libtaxii.clients` Module
-==============================
+clients Module
+==============
 
 .. module:: libtaxii.clients
 

--- a/docs/api/common.rst
+++ b/docs/api/common.rst
@@ -1,5 +1,5 @@
-:mod:`libtaxii.common` Module
-=============================
+common Module
+=============
 
 .. automodule:: libtaxii.common
 

--- a/docs/api/constants.rst
+++ b/docs/api/constants.rst
@@ -1,5 +1,5 @@
-:mod:`libtaxii.constants` Module
-================================
+constants Module
+================
 
 .. module:: libtaxii.constants
 

--- a/docs/api/libtaxii.rst
+++ b/docs/api/libtaxii.rst
@@ -1,5 +1,5 @@
-:mod:`libtaxii` Module
-=======================
+libtaxii Module
+===============
 
 .. module:: libtaxii
 

--- a/docs/api/messages_10.rst
+++ b/docs/api/messages_10.rst
@@ -1,5 +1,5 @@
-:mod:`libtaxii.messages_10` Module
-==================================
+messages_10 Module
+==================
 
 .. automodule:: libtaxii.messages_10
 

--- a/docs/api/messages_11.rst
+++ b/docs/api/messages_11.rst
@@ -1,5 +1,5 @@
-:mod:`libtaxii.messages_11` Module
-==================================
+messages_11 Module
+==================
 
 .. automodule:: libtaxii.messages_11
 

--- a/docs/api/query.rst
+++ b/docs/api/query.rst
@@ -1,5 +1,5 @@
-:mod:`libtaxii.taxii_default_query` Module
-==========================================
+taxii_default_query Module
+==========================
 
 .. automodule:: libtaxii.taxii_default_query
 

--- a/docs/api/validation.rst
+++ b/docs/api/validation.rst
@@ -1,5 +1,5 @@
-:mod:`libtaxii.validation` Module
-=================================
+validation Module
+=================
 
 .. _apivalidation:
 


### PR DESCRIPTION
# Summary

The API documentation currently has poorly formatted navigation, see [this link](https://libtaxii.readthedocs.io/en/stable/api/modules.html). In order to fix this, we simply remove the RST `mod` directive from the title of each of the API auto-generated docs and we are good to go. It will now look like this:

![image](https://user-images.githubusercontent.com/26469747/115325858-36d7f180-a141-11eb-84d4-dae739327fec.png)

This is really a QoL improvement, however this is really something that should have been fixed a long time ago.