### PR TITLE
Added support for python3 with poll_client

### DIFF
--- a/libtaxii/scripts/__init__.py
+++ b/libtaxii/scripts/__init__.py
@@ -311,7 +311,7 @@ class TaxiiScript(object):
 
             if write:
                 with io.open(filename, 'wb') as f:
-                    f.write(cb.content)
+                    f.write(cb.content.encode())
 
             print("%s%s" % (message, filename))
 
@@ -356,7 +356,7 @@ class TaxiiScript(object):
 
             if write:
                 with io.open(filename, 'wb') as f:
-                    f.write(cb.content)
+                    f.write(cb.content.encode())
 
             print("%s%s" % (message, filename))
 


### PR DESCRIPTION
I got the following error when using poll_client in Python 3.7.

```
Traceback (most recent call last):
  File "/Library/Python/3.7/site-packages/libtaxii/scripts/__init__.py", line 428, in __call__
    self.handle_response(r, args)
  File "poll_client.py", line 87, in handle_response
    self.write_cbs_from_poll_response_11(response, dest_dir=args.dest_dir, write_type_=args.write_type)
  File "/Library/Python/3.7/site-packages/libtaxii/scripts/__init__.py", line 359, in write_cbs_from_poll_response_11
    f.write(cb.content)
TypeError: a bytes-like object is required, not 'str'
```

After changing to encode the content, it worked in Python3 as well.